### PR TITLE
Correct reference to dataShards

### DIFF
--- a/examples/simple-encoder.go
+++ b/examples/simple-encoder.go
@@ -67,7 +67,7 @@ func main() {
 		flag.Usage()
 		os.Exit(1)
 	}
-	if *data > 257 {
+	if *dataShards > 257 {
 		fmt.Fprintf(os.Stderr, "Error: Too many data shards\n")
 		os.Exit(1)
 	}


### PR DESCRIPTION
Quick fix to get examples/simple-encoder working -- reference to 'data' should be 'dataShards'