### PR TITLE
Improve test coverage

### DIFF
--- a/matrix.go
+++ b/matrix.go
@@ -104,10 +104,7 @@ func (m matrix) Multiply(right matrix) (matrix, error) {
 	if len(m[0]) != len(right) {
 		return nil, fmt.Errorf("columns on left (%d) is different than rows on right (%d)", len(m[0]), len(right))
 	}
-	result, err := newMatrix(len(m), len(right[0]))
-	if err != nil {
-		return nil, err
-	}
+	result, _ := newMatrix(len(m), len(right[0]))
 	for r, row := range result {
 		for c := range row {
 			var value byte
@@ -202,16 +199,10 @@ func (m matrix) Invert() (matrix, error) {
 	}
 
 	size := len(m)
-	work, err := identityMatrix(size)
-	if err != nil {
-		return nil, err
-	}
-	work, err = m.Augment(work)
-	if err != nil {
-		return nil, err
-	}
+	work, _ := identityMatrix(size)
+	work, _ = m.Augment(work)
 
-	err = work.gaussianElimination()
+	err := work.gaussianElimination()
 	if err != nil {
 		return nil, err
 	}

--- a/reedsolomon.go
+++ b/reedsolomon.go
@@ -120,19 +120,9 @@ func New(dataShards, parityShards int) (Encoder, error) {
 	// This will make the top square be the identity matrix, but
 	// preserve the property that any square subset of rows  is
 	// invertible.
-	top, err := vm.SubMatrix(0, 0, dataShards, dataShards)
-	if err != nil {
-		return nil, err
-	}
-
-	top, err = top.Invert()
-	if err != nil {
-		return nil, err
-	}
-	r.m, err = vm.Multiply(top)
-	if err != nil {
-		return nil, err
-	}
+	top, _ := vm.SubMatrix(0, 0, dataShards, dataShards)
+	top, _ = top.Invert()
+	r.m, _ = vm.Multiply(top)
 
 	r.parity = make([][]byte, parityShards)
 	for i := range r.parity {

--- a/reedsolomon.go
+++ b/reedsolomon.go
@@ -242,7 +242,7 @@ func (r reedSolomon) codeSomeShardsP(matrixRows, inputs, outputs [][]byte, outpu
 	wg.Wait()
 }
 
-// checkSomeShards is nostly the same as codeSomeShards,
+// checkSomeShards is mostly the same as codeSomeShards,
 // except this will check values and return
 // as soon as a difference is found.
 func (r reedSolomon) checkSomeShards(matrixRows, inputs, toCheck [][]byte, outputCount, byteCount int) bool {
@@ -404,7 +404,7 @@ func (r reedSolomon) Reconstruct(shards [][]byte) error {
 	// Invert the matrix, so we can go from the encoded shards
 	// back to the original data.  Then pull out the row that
 	// generates the shard that we want to decode.  Note that
-	// since this matrix maps back to the orginal data, it can
+	// since this matrix maps back to the original data, it can
 	// be used to create a data shard, but not a parity shard.
 	dataDecodeMatrix, err := subMatrix.Invert()
 	if err != nil {
@@ -457,7 +457,7 @@ var ErrShortData = errors.New("not enough data to fill the number of requested s
 // and create empty parity shards.
 //
 // The data will be split into equally sized shards.
-// If the data size isn't dividable by the number of shards,
+// If the data size isn't divisible by the number of shards,
 // the last shard will contain extra zeros.
 //
 // There must be at least the same number of bytes as there are data shards,
@@ -470,19 +470,19 @@ func (r reedSolomon) Split(data []byte) ([][]byte, error) {
 		return nil, ErrShortData
 	}
 	perShard := (len(data) + r.DataShards - 1) / r.DataShards
+
+	// Fill data shards.
 	dst := make([][]byte, r.Shards)
-	for i := 0; i < r.DataShards; i++ {
-		if i < r.DataShards-1 {
-			dst[i] = data[perShard*i : perShard*i+perShard]
-		} else {
-			dst[i] = make([]byte, perShard)
-			copy(dst[i], data[perShard*i:])
-		}
+	for i := 0; i < r.DataShards-1; i++ {
+		dst[i] = data[:perShard]
+		data = data[perShard:]
 	}
+	// The last data shard must be zero-padded.
+	dst[r.DataShards-1] = append(data, make([]byte, perShard-len(data))...)
 
 	// Create empty parity shards.
-	for i := 0; i < r.ParityShards; i++ {
-		dst[i+r.DataShards] = make([]byte, perShard)
+	for i := r.DataShards; i < r.Shards; i++ {
+		dst[i] = make([]byte, perShard)
 	}
 	return dst, nil
 }
@@ -510,20 +510,17 @@ func (r reedSolomon) Join(dst io.Writer, shards [][]byte, outSize int) error {
 	}
 
 	// Copy data to dst
-	written := 0
+	write := outSize
 	for _, shard := range shards {
-		write := len(shard)
-		if written+write > outSize {
-			write = outSize - written
+		if write < len(shard) {
+			_, err := dst.Write(shard[:write])
+			return err
 		}
-		_, err := io.CopyN(dst, bytes.NewBuffer(shard), int64(write))
+		n, err := dst.Write(shard)
 		if err != nil {
 			return err
 		}
-		written += write
-		if written == outSize {
-			break
-		}
+		write -= n
 	}
 	return nil
 }

--- a/reedsolomon.go
+++ b/reedsolomon.go
@@ -309,9 +309,6 @@ var ErrShardSize = errors.New("shard sizes does not match")
 // or 0, if allowed. An error is returned if this fails.
 // An error is also returned if all shards are size 0.
 func checkShards(shards [][]byte, nilok bool) error {
-	if len(shards) == 0 {
-		return ErrShardNoData
-	}
 	size := shardSize(shards)
 	if size == 0 {
 		return ErrShardNoData

--- a/reedsolomon.go
+++ b/reedsolomon.go
@@ -388,10 +388,7 @@ func (r reedSolomon) Reconstruct(shards [][]byte) error {
 	// correspond to the rows of the submatrix.  These shards
 	// will be the input to the decoding process that re-creates
 	// the missing data shards.
-	subMatrix, err := newMatrix(r.DataShards, r.DataShards)
-	if err != nil {
-		return err
-	}
+	subMatrix, _ := newMatrix(r.DataShards, r.DataShards)
 	subShards := make([][]byte, r.DataShards)
 	subMatrixRow := 0
 	for matrixRow := 0; matrixRow < r.Shards && subMatrixRow < r.DataShards; matrixRow++ {

--- a/reedsolomon_test.go
+++ b/reedsolomon_test.go
@@ -138,17 +138,18 @@ func TestOneEncode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	shards := make([][]byte, 10)
-	shards[0] = []byte{0, 1}
-	shards[1] = []byte{4, 5}
-	shards[2] = []byte{2, 3}
-	shards[3] = []byte{6, 7}
-	shards[4] = []byte{8, 9}
-	shards[5] = []byte{0, 0}
-	shards[6] = []byte{0, 0}
-	shards[7] = []byte{0, 0}
-	shards[8] = []byte{0, 0}
-	shards[9] = []byte{0, 0}
+	shards := [][]byte{
+		{0, 1},
+		{4, 5},
+		{2, 3},
+		{6, 7},
+		{8, 9},
+		{0, 0},
+		{0, 0},
+		{0, 0},
+		{0, 0},
+		{0, 0},
+	}
 	codec.Encode(shards)
 	if shards[5][0] != 12 || shards[5][1] != 13 {
 		t.Fatal("shard 5 mismatch")

--- a/reedsolomon_test.go
+++ b/reedsolomon_test.go
@@ -512,28 +512,35 @@ func TestEncoderReconstruct(t *testing.T) {
 	}
 }
 
-func TestMatrices(t *testing.T) {
-	_, err := New(10, 500)
-	if err != nil {
-		t.Fatal("creating matrix size", 10, 500, ":", err)
-	}
-	_, err = New(256, 256)
-	if err != nil {
-		t.Fatal("creating matrix size", 256, 256, ":", err)
-	}
-	_, err = New(257, 10)
-	if err != ErrInvShardNum {
-		t.Fatal("Expected ErrInvShardNum, but got", err)
-	}
-
-}
-
 func TestAllMatrices(t *testing.T) {
 	t.Skip("Skipping slow matrix check")
 	for i := 1; i < 257; i++ {
 		_, err := New(i, i)
 		if err != nil {
 			t.Fatal("creating matrix size", i, i, ":", err)
+		}
+	}
+}
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		data, parity int
+		err          error
+	}{
+		{10, 500, nil},
+		{256, 256, nil},
+
+		{0, 1, ErrInvShardNum},
+		{1, 0, ErrInvShardNum},
+		{257, 1, ErrInvShardNum},
+
+		// overflow causes r.Shards to be negative
+		{256, int(^uint(0) >> 1), errInvalidRowSize},
+	}
+	for _, test := range tests {
+		_, err := New(test.data, test.parity)
+		if err != test.err {
+			t.Errorf("New(%v, %v): expected %v, got %v", test.data, test.parity, test.err, err)
 		}
 	}
 }

--- a/reedsolomon_test.go
+++ b/reedsolomon_test.go
@@ -8,6 +8,7 @@
 package reedsolomon
 
 import (
+	"bytes"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -546,11 +547,21 @@ func TestEncoderReconstruct(t *testing.T) {
 		t.Fatal("not ok:", ok, "err:", err)
 	}
 
-	// Delete a shard
+	// Recover original bytes
+	buf := new(bytes.Buffer)
+	err = enc.Join(buf, shards, len(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(buf.Bytes(), data) {
+		t.Fatal("recovered bytes do not match")
+	}
+
+	// Corrupt a shard
 	shards[0] = nil
 	shards[1][0], shards[1][500] = 75, 75
 
-	// Should reconstruct
+	// Should reconstruct (but with corrupted data)
 	err = enc.Reconstruct(shards)
 	if err != nil {
 		t.Fatal(err)
@@ -561,6 +572,52 @@ func TestEncoderReconstruct(t *testing.T) {
 	if ok || err != nil {
 		t.Fatal("error or ok:", ok, "err:", err)
 	}
+
+	// Recovered data should not match original
+	buf.Reset()
+	err = enc.Join(buf, shards, len(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(buf.Bytes(), data) {
+		t.Fatal("corrupted data matches original")
+	}
+}
+
+func TestSplitJoin(t *testing.T) {
+	var data = make([]byte, 250000)
+	fillRandom(data)
+
+	enc, _ := New(5, 3)
+	shards, err := enc.Split(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = enc.Split([]byte{})
+	if err != ErrShortData {
+		t.Errorf("expected %v, got %v", ErrShortData, err)
+	}
+
+	buf := new(bytes.Buffer)
+	err = enc.Join(buf, shards, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(buf.Bytes(), data[:50]) {
+		t.Fatal("recovered data does match original")
+	}
+
+	err = enc.Join(buf, [][]byte{}, 0)
+	if err != ErrTooFewShards {
+		t.Errorf("expected %v, got %v", ErrTooFewShards, err)
+	}
+
+	err = enc.Join(buf, shards, len(data)+1)
+	if err != ErrShortData {
+		t.Errorf("expected %v, got %v", ErrShortData, err)
+	}
+
 }
 
 func TestAllMatrices(t *testing.T) {

--- a/reedsolomon_test.go
+++ b/reedsolomon_test.go
@@ -40,6 +40,18 @@ func TestEncoding(t *testing.T) {
 	if !ok {
 		t.Fatal("Verification failed")
 	}
+
+	err = r.Encode(make([][]byte, 1))
+	if err != ErrTooFewShards {
+		t.Errorf("expected %v, got %v", ErrTooFewShards, err)
+	}
+
+	badShards := make([][]byte, 13)
+	badShards[0] = make([]byte, 1)
+	err = r.Encode(badShards)
+	if err != ErrShardSize {
+		t.Errorf("expected %v, got %v", ErrShardSize, err)
+	}
 }
 
 func TestReconstruct(t *testing.T) {

--- a/reedsolomon_test.go
+++ b/reedsolomon_test.go
@@ -120,6 +120,7 @@ func TestVerify(t *testing.T) {
 	if !ok {
 		t.Fatal("Verification failed")
 	}
+
 	// Put in random data. Verification should fail
 	fillRandom(shards[10])
 	ok, err = r.Verify(shards)
@@ -142,6 +143,16 @@ func TestVerify(t *testing.T) {
 	}
 	if ok {
 		t.Fatal("Verification did not fail")
+	}
+
+	_, err = r.Verify(make([][]byte, 1))
+	if err != ErrTooFewShards {
+		t.Errorf("expected %v, got %v", ErrTooFewShards, err)
+	}
+
+	_, err = r.Verify(make([][]byte, 14))
+	if err != ErrShardNoData {
+		t.Errorf("expected %v, got %v", ErrShardNoData, err)
 	}
 }
 

--- a/reedsolomon_test.go
+++ b/reedsolomon_test.go
@@ -75,6 +75,13 @@ func TestReconstruct(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Reconstruct with all shards present
+	err = r.Reconstruct(shards)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Reconstruct with 10 shards present
 	shards[0] = nil
 	shards[7] = nil
 	shards[11] = nil
@@ -90,6 +97,26 @@ func TestReconstruct(t *testing.T) {
 	}
 	if !ok {
 		t.Fatal("Verification failed")
+	}
+
+	// Reconstruct with 9 shards present (should fail)
+	shards[0] = nil
+	shards[4] = nil
+	shards[7] = nil
+	shards[11] = nil
+
+	err = r.Reconstruct(shards)
+	if err != ErrTooFewShards {
+		t.Errorf("expected %v, got %v", ErrTooFewShards, err)
+	}
+
+	err = r.Reconstruct(make([][]byte, 1))
+	if err != ErrTooFewShards {
+		t.Errorf("expected %v, got %v", ErrTooFewShards, err)
+	}
+	err = r.Reconstruct(make([][]byte, 13))
+	if err != ErrShardNoData {
+		t.Errorf("expected %v, got %v", ErrShardNoData, err)
 	}
 }
 


### PR DESCRIPTION
Coverage 74.9% -> 92.9%

I would also consider dropping the Encoder interface and renaming the `reedSolomon` type to `Encoder`. I don't think an interface is very useful if there's only one type that implements it.

btw, this package rocks. Previously we were using longhair + cgo, but this is much more convenient (and as fast or faster). Thank you!