### PR TITLE
Fix Split panic

### DIFF
--- a/reedsolomon.go
+++ b/reedsolomon.go
@@ -469,21 +469,21 @@ func (r reedSolomon) Split(data []byte) ([][]byte, error) {
 	if len(data) < r.DataShards {
 		return nil, ErrShortData
 	}
+
+	// Calculate number of bytes per shard.
 	perShard := (len(data) + r.DataShards - 1) / r.DataShards
 
-	// Fill data shards.
+	// Pad data to r.Shards*perShard.
+	padding := make([]byte, (r.Shards*perShard)-len(data))
+	data = append(data, padding...)
+
+	// Split into equal-length shards.
 	dst := make([][]byte, r.Shards)
-	for i := 0; i < r.DataShards-1; i++ {
+	for i := range dst {
 		dst[i] = data[:perShard]
 		data = data[perShard:]
 	}
-	// The last data shard must be zero-padded.
-	dst[r.DataShards-1] = append(data, make([]byte, perShard-len(data))...)
 
-	// Create empty parity shards.
-	for i := r.DataShards; i < r.Shards; i++ {
-		dst[i] = make([]byte, perShard)
-	}
 	return dst, nil
 }
 

--- a/reedsolomon_test.go
+++ b/reedsolomon_test.go
@@ -587,6 +587,7 @@ func TestEncoderReconstruct(t *testing.T) {
 
 func TestSplitJoin(t *testing.T) {
 	var data = make([]byte, 250000)
+	rand.Seed(0)
 	fillRandom(data)
 
 	enc, _ := New(5, 3)


### PR DESCRIPTION
Certain choices of `r.DataShards` and `r.ParityShards` would cause a panic when a slice of a certain length was passed to `Split` For example:
```go
enc, _ = New(6, 1)
enc.Split(make([]byte, 7)) // panic: runtime error: slice bounds out of range
```
The problem is that `Split` wants to create 6 data shards of length 2, but there are only 7 bytes of input. After the first 4 data shards are filled, `Split` runs out of data earlier than expected and panics.

To fix this, I simply applied the zero-padding *before* splitting instead of after. The result is a single straightforward `for` loop; cleaner and bug-free!

This bug was discovered by [go-fuzz](https://github.com/dvyukov/go-fuzz/). Fuzzing has not uncovered any additional bugs.