### PR TITLE
Tests: backport go1.6 rand.Read for speedup tests

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -11,9 +11,13 @@ import (
 	"github.com/klauspost/reedsolomon"
 )
 
-func fillRandom(b []byte) {
-	for i := range b {
-		b[i] = byte(rand.Int() & 0xff)
+func fillRandom(p []byte) {
+	for i := 0; i < len(p); i += 7 {
+		val := rand.Int63()
+		for j := 0; i+j < len(p) && j < 7; j++ {
+			p[i+j] = byte(val)
+			val >>= 8
+		}
 	}
 }
 

--- a/reedsolomon_test.go
+++ b/reedsolomon_test.go
@@ -236,9 +236,13 @@ func TestOneEncode(t *testing.T) {
 
 }
 
-func fillRandom(b []byte) {
-	for i := range b {
-		b[i] = byte(rand.Int() & 0xff)
+func fillRandom(p []byte) {
+	for i := 0; i < len(p); i += 7 {
+		val := rand.Int63()
+		for j := 0; i+j < len(p) && j < 7; j++ {
+			p[i+j] = byte(val)
+			val >>= 8
+		}
 	}
 }
 

--- a/streaming_test.go
+++ b/streaming_test.go
@@ -119,9 +119,7 @@ func TestStreamEncodingConcurrent(t *testing.T) {
 
 func randomBuffer(length int) *bytes.Buffer {
 	b := make([]byte, length)
-	for i := range b {
-		b[i] = byte(rand.Int() & 0xff)
-	}
+	fillRandom(b)
 	return bytes.NewBuffer(b)
 }
 
@@ -129,9 +127,7 @@ func randomBytes(n, length int) [][]byte {
 	bufs := make([][]byte, n)
 	for j := range bufs {
 		bufs[j] = make([]byte, length)
-		for i := range bufs[j] {
-			bufs[j][i] = byte(rand.Int() & 0xff)
-		}
+		fillRandom(bufs[j])
 	}
 	return bufs
 }


### PR DESCRIPTION
with E5-2630 v2
before:
```
github.com/klauspost/reedsolomon        17.355s
```
after:
```
github.com/klauspost/reedsolomon        4.503s
```