### PR TITLE
Optimized encoding & decoding goroutines number

### DIFF
--- a/reedsolomon.go
+++ b/reedsolomon.go
@@ -189,7 +189,7 @@ func (r reedSolomon) Verify(shards [][]byte) (bool, error) {
 // number of matrix rows used, is determined by
 // outputCount, which is the number of outputs to compute.
 func (r reedSolomon) codeSomeShards(matrixRows, inputs, outputs [][]byte, outputCount, byteCount int) {
-	if runtime.GOMAXPROCS(0) > 1 && len(inputs[0]) > splitSize {
+	if runtime.GOMAXPROCS(0) > 1 && len(inputs[0]) > minSplitSize {
 		r.codeSomeShardsP(matrixRows, inputs, outputs, outputCount, byteCount)
 		return
 	}
@@ -205,24 +205,24 @@ func (r reedSolomon) codeSomeShards(matrixRows, inputs, outputs [][]byte, output
 	}
 }
 
-// How many bytes per goroutine.
-const splitSize = 512
+const (
+	minSplitSize  = 512 // min split size per goroutine
+	maxGoroutines = 50  // max goroutines number for encoding & decoding
+)
 
 // Perform the same as codeSomeShards, but split the workload into
 // several goroutines.
 func (r reedSolomon) codeSomeShardsP(matrixRows, inputs, outputs [][]byte, outputCount, byteCount int) {
 	var wg sync.WaitGroup
-	left := byteCount
+	do := byteCount / maxGoroutines
+	if do < minSplitSize {
+		do = minSplitSize
+	}
 	start := 0
-	for {
-		do := left
-		if do > splitSize {
-			do = splitSize
+	for start < byteCount {
+		if start+do > byteCount {
+			do = byteCount - start
 		}
-		if do == 0 {
-			break
-		}
-		left -= do
 		wg.Add(1)
 		go func(start, stop int) {
 			for c := 0; c < r.DataShards; c++ {
@@ -246,22 +246,19 @@ func (r reedSolomon) codeSomeShardsP(matrixRows, inputs, outputs [][]byte, outpu
 // except this will check values and return
 // as soon as a difference is found.
 func (r reedSolomon) checkSomeShards(matrixRows, inputs, toCheck [][]byte, outputCount, byteCount int) bool {
-	var wg sync.WaitGroup
-	left := byteCount
-	start := 0
-
 	same := true
 	var mu sync.RWMutex // For above
 
-	for {
-		do := left
-		if do > splitSize {
-			do = splitSize
+	var wg sync.WaitGroup
+	do := byteCount / maxGoroutines
+	if do < minSplitSize {
+		do = minSplitSize
+	}
+	start := 0
+	for start < byteCount {
+		if start+do > byteCount {
+			do = byteCount - start
 		}
-		if do == 0 {
-			break
-		}
-		left -= do
 		wg.Add(1)
 		go func(start, do int) {
 			defer wg.Done()


### PR DESCRIPTION
I found that the origin implement use so many goroutines (`shardSize / 512`) to encode & decode data 
it may make some effects to performance.

here is my patches & benchmarks for the issue. (hope testing under more enviroments)

`hardware: E5-2630 v2  (Intel x86-64 with ssse3)`
`software: linux, go1.6, GOMAXPROCS=2`
```
Performances                          before          after         change

BenchmarkEncode10x2x10000-2           2884.95 MB/s    2837.93 MB/s  0.98x
BenchmarkEncode100x20x10000-2          593.93 MB/s     577.17 MB/s  0.97x
BenchmarkEncode17x3x1M-2              2903.74 MB/s    5197.99 MB/s  1.80x
BenchmarkEncode10x4x16M-2             1992.13 MB/s    3689.69 MB/s  1.85x
BenchmarkEncode5x2x1M-2               2883.78 MB/s    7506.19 MB/s  2.60x
BenchmarkEncode10x2x1M-2              3205.63 MB/s    7848.12 MB/s  2.45x
BenchmarkEncode10x4x1M-2              2218.35 MB/s    3998.35 MB/s  1.80x
BenchmarkEncode50x20x1M-2              579.24 MB/s     641.08 MB/s  1.11x
BenchmarkEncode17x3x16M-2             2652.36 MB/s    4775.41 MB/s  1.80x
BenchmarkVerify10x2x10000-2           1327.27 MB/s    1837.41 MB/s  1.38x
BenchmarkVerify50x5x50000-2           1481.89 MB/s    2684.57 MB/s  1.81x
BenchmarkVerify10x2x1M-2              1553.91 MB/s    5704.71 MB/s  3.67x
BenchmarkVerify5x2x1M-2                939.90 MB/s    4949.30 MB/s  5.26x
BenchmarkVerify10x4x1M-2               956.89 MB/s    3191.01 MB/s  3.33x
BenchmarkVerify50x20x1M-2              490.49 MB/s     823.46 MB/s  1.68x
BenchmarkVerify10x4x16M-2             1078.03 MB/s    3196.97 MB/s  2.97x
BenchmarkStreamEncode10x2x10000-2        2.40 MB/s      12.10 MB/s  5.04x
BenchmarkStreamEncode100x20x10000-2      6.72 MB/s      10.72 MB/s  1.60x
BenchmarkStreamEncode17x3x1M-2         390.75 MB/s     845.08 MB/s  2.16x
BenchmarkStreamEncode10x4x16M-2       1175.93 MB/s    1803.71 MB/s  1.53x
BenchmarkStreamEncode5x2x1M-2          207.85 MB/s     790.02 MB/s  3.80x
BenchmarkStreamEncode10x2x1M-2         296.77 MB/s     872.41 MB/s  2.94x
BenchmarkStreamEncode10x4x1M-2         264.43 MB/s     699.25 MB/s  2.64x
BenchmarkStreamEncode50x20x1M-2        284.93 MB/s     414.65 MB/s  1.46x
BenchmarkStreamEncode17x3x16M-2       1439.13 MB/s    1933.42 MB/s  1.34x
BenchmarkStreamVerify10x2x10000-2        2.33 MB/s      12.07 MB/s  5.18x
BenchmarkStreamVerify50x5x50000-2       86.53 MB/s     136.02 MB/s  1.57x
BenchmarkStreamVerify10x2x1M-2         315.65 MB/s     909.44 MB/s  2.88x
BenchmarkStreamVerify5x2x1M-2          180.45 MB/s     772.42 MB/s  4.28x
BenchmarkStreamVerify10x4x1M-2         310.35 MB/s     779.26 MB/s  2.51x
BenchmarkStreamVerify50x20x1M-2        547.23 MB/s     773.74 MB/s  1.41x
BenchmarkStreamVerify10x4x16M-2       4128.01 MB/s    6606.43 MB/s  1.60x
```