### PR TITLE
ErrShortData shouldn't be returned for data less than dataShards.

### DIFF
--- a/reedsolomon.go
+++ b/reedsolomon.go
@@ -57,8 +57,8 @@ type Encoder interface {
 	// If the data size isn't dividable by the number of shards,
 	// the last shard will contain extra zeros.
 	//
-	// There must be at least the same number of bytes as there are data shards,
-	// otherwise ErrShortData will be returned.
+	// There must be at least 1byte otherwise ErrShortData will be
+	// returned.
 	//
 	// The data will not be copied, except for the last shard, so you
 	// should not modify the data of the input slice afterwards.
@@ -457,16 +457,15 @@ var ErrShortData = errors.New("not enough data to fill the number of requested s
 // If the data size isn't divisible by the number of shards,
 // the last shard will contain extra zeros.
 //
-// There must be at least the same number of bytes as there are data shards,
-// otherwise ErrShortData will be returned.
+// There must be at least 1byte otherwise ErrShortData will be
+// returned.
 //
 // The data will not be copied, except for the last shard, so you
 // should not modify the data of the input slice afterwards.
 func (r reedSolomon) Split(data []byte) ([][]byte, error) {
-	if len(data) < r.DataShards {
+	if len(data) == 0 {
 		return nil, ErrShortData
 	}
-
 	// Calculate number of bytes per shard.
 	perShard := (len(data) + r.DataShards - 1) / r.DataShards
 

--- a/streaming.go
+++ b/streaming.go
@@ -77,8 +77,8 @@ type StreamEncoder interface {
 	// the last shard will contain extra zeros.
 	//
 	// You must supply the total size of your input.
-	// 'ErrShortData' will be returned if it is unable to retrieve the number of bytes
-	// indicated.
+	// 'ErrShortData' will be returned if it is unable to retrieve the
+	// number of bytes indicated.
 	Split(data io.Reader, dst []io.Writer, size int64) (err error)
 
 	// Join the shards and write the data segment to dst.
@@ -537,13 +537,12 @@ func (r rsStream) Join(dst io.Writer, shards []io.Reader, outSize int64) error {
 // the last shard will contain extra zeros.
 //
 // You must supply the total size of your input.
-// 'ErrShortData' will be returned if it is unable to retrieve the number of bytes
-// indicated.
+// 'ErrShortData' will be returned if it is unable to retrieve the
+// number of bytes indicated.
 func (r rsStream) Split(data io.Reader, dst []io.Writer, size int64) error {
-	if size < int64(r.r.DataShards) {
+	if size == 0 {
 		return ErrShortData
 	}
-
 	if len(dst) != r.r.DataShards {
 		return ErrInvShardNum
 	}


### PR DESCRIPTION
The reasoning behind this is that if we have a data block number
of 10, and parity of 10.  Restricting input such that files of
size < 10Bytes should be errored out doesn't seem like the right
approach.

Most erasure subsystems will have static data and parity blocks,
in such case erroring out is not correct since reedsolomon itself
doesn't provide this limitation (please correct me here if i am
wrong :-)).

So removing the check itself is not a problem since most of the
data after the split would be padded with zeros, which is okay
and should be left as application optimization if they wish to
pack small files in this range.

ErrShortData will be still returned in case if the size of data
is empty, or in case of streaming if the size == 0.