### PR TITLE
Ensure all joined data gets written

### DIFF
--- a/reedsolomon.go
+++ b/reedsolomon.go
@@ -522,5 +522,6 @@ func (r reedSolomon) Join(dst io.Writer, shards [][]byte, outSize int) error {
 		}
 		write -= n
 	}
+	dst.Flush()
 	return nil
 }


### PR DESCRIPTION
Calling dst.Flush() makes sure the data gets actually written to the underlying io.Writer. This isn't usually a problem with file-based Writers, since closing the file will flush all data, but it's a common issue when operating a bufio Writer on a bytes.Buffer.