### PR TITLE
Make Join return an error if a reconstruction is required first

### DIFF
--- a/reedsolomon_test.go
+++ b/reedsolomon_test.go
@@ -482,6 +482,12 @@ func TestSplitJoin(t *testing.T) {
 	if err != ErrShortData {
 		t.Errorf("expected %v, got %v", ErrShortData, err)
 	}
+
+	shards[0] = nil
+	err = enc.Join(buf, shards, len(data))
+	if err != ErrReconstructRequired {
+		t.Errorf("expected %v, got %v", ErrReconstructRequired, err)
+	}
 }
 
 func TestCodeSomeShards(t *testing.T) {


### PR DESCRIPTION
If one or more required data shards are still nil and we can't correctly join
them before a reconstruction, return ErrReconstructRequired.

Fixes #33