### PR TITLE
Add Inverse Matrix caching in a Thread-Safe Lookup Tree

### DIFF
--- a/inversion_tree.go
+++ b/inversion_tree.go
@@ -46,7 +46,7 @@ func (n inversionNode) insertInvertedMatrix(invalidIndices []int, matrix matrix,
 	}
 
 	if len(invalidIndices) > 1 {
-		node.insertInvertedMatrix(invalidIndices[1:], matrix, invalidIndices[0]+1, shards)
+		node.insertInvertedMatrix(invalidIndices[1:], matrix, shards, invalidIndices[0]+1)
 	} else {
 		node.mutex.Lock()
 		defer node.mutex.Unlock()

--- a/inversion_tree.go
+++ b/inversion_tree.go
@@ -1,64 +1,138 @@
+/**
+ * A thread-safe tree which caches inverted matrices.
+ *
+ * Copyright 2016, Peter Collins
+ */
+
 package reedsolomon
 
 import (
 	"sync"
 )
 
+// The tree uses a Reader-Writer mutex to make it thread-safe
+// when accessing cached matrices and inserting new ones.
+type inversionTree struct {
+	mutex sync.RWMutex
+	root  inversionNode
+}
+
 type inversionNode struct {
-	mutex    sync.RWMutex
 	matrix   matrix
 	children []*inversionNode
 }
 
-func newInversionTree(dataShards, parityShards int) inversionNode {
+// newInversionTree initializes a tree for storing inverted matrices.
+// Note that the root node is the identity matrix as it implies
+// there were no errors with the original data.
+func newInversionTree(dataShards, parityShards int) inversionTree {
 	identity, _ := identityMatrix(dataShards)
-	return inversionNode{
+	root := inversionNode{
 		matrix:   identity,
-		mutex:    sync.RWMutex{},
 		children: make([]*inversionNode, dataShards+parityShards),
+	}
+	return inversionTree{
+		mutex: sync.RWMutex{},
+		root:  root,
 	}
 }
 
-func (n inversionNode) GetInvertedMatrix(invalidIndices []int) matrix {
-	return n.getInvertedMatrix(invalidIndices, 0)
+// GetInvertedMatrix returns the cached inverted matrix or nil if it
+// is not found in the tree keyed on the indices of invalid rows.
+func (t inversionTree) GetInvertedMatrix(invalidIndices []int) matrix {
+	// Lock the tree for reading before accessing the tree.
+	t.mutex.RLock()
+	defer t.mutex.RUnlock()
+
+	// Recursively search for the inverted matrix in the tree, passing in
+	// 0 as the parent index as we start at the root of the tree.
+	return t.root.getInvertedMatrix(invalidIndices, 0)
 }
 
-func (n inversionNode) InsertInvertedMatrix(invalidIndices []int, matrix matrix, shards int) {
-	n.insertInvertedMatrix(invalidIndices, matrix, shards, 0)
+// InsertInvertedMatrix inserts a new inverted matrix into the tree
+// keyed by the indices of invalid rows.  The total number of shards
+// is required for creating the proper length lists of child nodes for
+// each node.
+func (t inversionTree) InsertInvertedMatrix(invalidIndices []int, matrix matrix, shards int) {
+	// Lock the tree for writing and reading before accessing the tree.
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	// Recursively create nodes for the inverted matrix in the tree until
+	// we reach the node to insert the matrix to.  We start by passing in
+	// 0 as the parent index as we start at the root of the tree.
+	t.root.insertInvertedMatrix(invalidIndices, matrix, shards, 0)
 }
 
 func (n inversionNode) getInvertedMatrix(invalidIndices []int, parent int) matrix {
-	n.mutex.RLock()
-	defer n.mutex.RUnlock()
+	// Get the child node to search next from the list of children.  The
+	// list of children starts relative to the parent index passed in
+	// because the indices of invalid rows is sorted (by default).  As we
+	// search recursively, the first invalid index gets popped off the list,
+	// so when searching through the list of children, use that first invalid
+	// index to find the child node.
+	firstIndex := invalidIndices[0]
+	node := n.children[firstIndex-parent]
 
-	node := n.children[invalidIndices[0]-parent]
+	// If the child node doesn't exist in the list yet, fail fast by
+	// returning, so we can construct and insert the proper inverted matrix.
 	if node == nil {
 		return nil
 	}
 
+	// If there's more than one invalid index left in the list we should
+	// keep searching recursively.
 	if len(invalidIndices) > 1 {
-		return node.getInvertedMatrix(invalidIndices[1:], invalidIndices[0]+1)
+		// Search recursively on the child node by passing in the invalid indices
+		// with the first index popped off the front.  Also the parent index to
+		// pass down is the first index plus one.
+		return node.getInvertedMatrix(invalidIndices[1:], firstIndex+1)
 	}
+	// If there aren't any more invalid indices to search, we've found our
+	// node.  Return it, however keep in mind that the matrix could still be
+	// nil because intermediary nodes in the tree are created sometimes with
+	// their inversion matrices uninitialized.
 	return n.matrix
 }
 
 func (n inversionNode) insertInvertedMatrix(invalidIndices []int, matrix matrix, shards, parent int) {
-	node := n.children[invalidIndices[0]-parent]
+	// As above, get the child node to search next from the list of children.
+	// The list of children starts relative to the parent index passed in
+	// because the indices of invalid rows is sorted (by default).  As we
+	// search recursively, the first invalid index gets popped off the list,
+	// so when searching through the list of children, use that first invalid
+	// index to find the child node.
+	firstIndex := invalidIndices[0]
+	node := n.children[firstIndex-parent]
+
+	// If the child node doesn't exist in the list yet, create a new
+	// node because we have the writer lock and add it to the list
+	// of children.
 	if node == nil {
-		n.mutex.Lock()
-		defer n.mutex.Unlock()
+		// Make the length of the list of children equal to the number
+		// of shards minus the first invalid index because the list of
+		// invalid indices is sorted, so only this length of errors
+		// are possible in the tree.
 		node = &inversionNode{
-			mutex:    sync.RWMutex{},
-			children: make([]*inversionNode, shards-invalidIndices[0]),
+			children: make([]*inversionNode, shards-firstIndex),
 		}
-		n.children[invalidIndices[0]-parent] = node
+		// Insert the new node into the tree at the first index relative
+		// to the parent index that was given in this recursive call.
+		n.children[firstIndex-parent] = node
 	}
 
+	// If there's more than one invalid index left in the list we should
+	// keep searching recursively in order to find the node to add our
+	// matrix.
 	if len(invalidIndices) > 1 {
-		node.insertInvertedMatrix(invalidIndices[1:], matrix, shards, invalidIndices[0]+1)
+		// As above, search recursively on the child node by passing in
+		// the invalid indices with the first index popped off the front.
+		// Also the total number of shards and parent index are passed down
+		// which is equal to the first index plus one.
+		node.insertInvertedMatrix(invalidIndices[1:], matrix, shards, firstIndex+1)
 	} else {
-		node.mutex.Lock()
-		defer node.mutex.Unlock()
+		// If there aren't any more invalid indices to search, we've found our
+		// node.  Cache the inverted matrix in this node.
 		node.matrix = matrix
 	}
 }

--- a/inversion_tree.go
+++ b/inversion_tree.go
@@ -1,0 +1,55 @@
+package reedsolomon
+
+import (
+	"sync"
+)
+
+type inversionNode struct {
+	mutex    sync.RWMutex
+	matrix   matrix
+	children []*inversionNode
+}
+
+func (n inversionNode) GetInvertedMatrix(invalidIndices []int) matrix {
+	return n.getInvertedMatrix(invalidIndices, 0)
+}
+
+func (n inversionNode) InsertInvertedMatrix(invalidIndices []int, matrix matrix, shards int) {
+	n.insertInvertedMatrix(invalidIndices, matrix, shards, 0)
+}
+
+func (n inversionNode) getInvertedMatrix(invalidIndices []int, parent int) matrix {
+	n.mutex.RLock()
+	defer n.mutex.RUnlock()
+
+	node := n.children[invalidIndices[0]-parent]
+	if node == nil {
+		return nil
+	}
+
+	if len(invalidIndices) > 1 {
+		return node.getInvertedMatrix(invalidIndices[1:], invalidIndices[0]+1)
+	}
+	return n.matrix
+}
+
+func (n inversionNode) insertInvertedMatrix(invalidIndices []int, matrix matrix, shards, parent int) {
+	node := n.children[invalidIndices[0]-parent]
+	if node == nil {
+		n.mutex.Lock()
+		defer n.mutex.Unlock()
+		node = &inversionNode{
+			mutex:    sync.RWMutex{},
+			children: make([]*inversionNode, shards-invalidIndices[0]),
+		}
+		n.children[invalidIndices[0]-parent] = node
+	}
+
+	if len(invalidIndices) > 1 {
+		node.insertInvertedMatrix(invalidIndices[1:], matrix, invalidIndices[0]+1, shards)
+	} else {
+		node.mutex.Lock()
+		defer node.mutex.Unlock()
+		node.matrix = matrix
+	}
+}

--- a/inversion_tree.go
+++ b/inversion_tree.go
@@ -10,6 +10,15 @@ type inversionNode struct {
 	children []*inversionNode
 }
 
+func newInversionTree(dataShards, parityShards int) inversionNode {
+	identity, _ := identityMatrix(dataShards)
+	return inversionNode{
+		matrix:   identity,
+		mutex:    sync.RWMutex{},
+		children: make([]*inversionNode, dataShards+parityShards),
+	}
+}
+
 func (n inversionNode) GetInvertedMatrix(invalidIndices []int) matrix {
 	return n.getInvertedMatrix(invalidIndices, 0)
 }

--- a/inversion_tree.go
+++ b/inversion_tree.go
@@ -14,7 +14,7 @@ import (
 // The tree uses a Reader-Writer mutex to make it thread-safe
 // when accessing cached matrices and inserting new ones.
 type inversionTree struct {
-	mutex sync.RWMutex
+	mutex *sync.RWMutex
 	root  inversionNode
 }
 
@@ -33,7 +33,7 @@ func newInversionTree(dataShards, parityShards int) inversionTree {
 		children: make([]*inversionNode, dataShards+parityShards),
 	}
 	return inversionTree{
-		mutex: sync.RWMutex{},
+		mutex: &sync.RWMutex{},
 		root:  root,
 	}
 }

--- a/inversion_tree.go
+++ b/inversion_tree.go
@@ -114,7 +114,7 @@ func (n inversionNode) getInvertedMatrix(invalidIndices []int, parent int) matri
 	// node.  Return it, however keep in mind that the matrix could still be
 	// nil because intermediary nodes in the tree are created sometimes with
 	// their inversion matrices uninitialized.
-	return n.matrix
+	return node.matrix
 }
 
 func (n inversionNode) insertInvertedMatrix(invalidIndices []int, matrix matrix, shards, parent int) {

--- a/inversion_tree_test.go
+++ b/inversion_tree_test.go
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for inversion tree.
+ *
+ * Copyright 2016, Peter Collins
+ */
+
+package reedsolomon
+
+import (
+	"testing"
+)
+
+func TestNewInversionTree(t *testing.T) {
+	tree := newInversionTree(3, 2)
+
+	children := len(tree.root.children)
+	if children != 5 {
+		t.Fatal("Root node children list length", children, "!=", 5)
+	}
+
+	str := tree.root.matrix.String()
+	expect := "[[1, 0, 0], [0, 1, 0], [0, 0, 1]]"
+	if str != expect {
+		t.Fatal(str, "!=", expect)
+	}
+}
+
+func TestGetInvertedMatrix(t *testing.T) {
+	tree := newInversionTree(3, 2)
+
+	matrix := tree.GetInvertedMatrix([]int{})
+	str := matrix.String()
+	expect := "[[1, 0, 0], [0, 1, 0], [0, 0, 1]]"
+	if str != expect {
+		t.Fatal(str, "!=", expect)
+	}
+
+	matrix = tree.GetInvertedMatrix([]int{1})
+	if matrix != nil {
+		t.Fatal(matrix, "!= nil")
+	}
+
+	matrix = tree.GetInvertedMatrix([]int{1, 2})
+	if matrix != nil {
+		t.Fatal(matrix, "!= nil")
+	}
+
+	matrix, err := newMatrix(3, 3)
+	if err != nil {
+		t.Fatalf("Failed initializing new Matrix : %s", err)
+	}
+	err = tree.InsertInvertedMatrix([]int{1}, matrix, 5)
+	if err != nil {
+		t.Fatalf("Failed inserting new Matrix : %s", err)
+	}
+
+	matrix = tree.GetInvertedMatrix([]int{1})
+	if matrix == nil {
+		t.Fatal(matrix, "== nil")
+	}
+}
+
+func TestInsertInvertedMatrix(t *testing.T) {
+	tree := newInversionTree(3, 2)
+
+	matrix, err := newMatrix(3, 3)
+	if err != nil {
+		t.Fatalf("Failed initializing new Matrix : %s", err)
+	}
+	err = tree.InsertInvertedMatrix([]int{1}, matrix, 5)
+	if err != nil {
+		t.Fatalf("Failed inserting new Matrix : %s", err)
+	}
+
+	err = tree.InsertInvertedMatrix([]int{}, matrix, 5)
+	if err == nil {
+		t.Fatal("Should have failed inserting the root node matrix", matrix)
+	}
+
+	matrix, err = newMatrix(3, 2)
+	if err != nil {
+		t.Fatalf("Failed initializing new Matrix : %s", err)
+	}
+	err = tree.InsertInvertedMatrix([]int{2}, matrix, 5)
+	if err == nil {
+		t.Fatal("Should have failed inserting a non-square matrix", matrix)
+	}
+
+	matrix, err = newMatrix(3, 3)
+	if err != nil {
+		t.Fatalf("Failed initializing new Matrix : %s", err)
+	}
+	err = tree.InsertInvertedMatrix([]int{0, 1}, matrix, 5)
+	if err != nil {
+		t.Fatalf("Failed inserting new Matrix : %s", err)
+	}
+}

--- a/inversion_tree_test.go
+++ b/inversion_tree_test.go
@@ -54,9 +54,12 @@ func TestGetInvertedMatrix(t *testing.T) {
 		t.Fatalf("Failed inserting new Matrix : %s", err)
 	}
 
-	matrix = tree.GetInvertedMatrix([]int{1})
-	if matrix == nil {
-		t.Fatal(matrix, "== nil")
+	cachedMatrix := tree.GetInvertedMatrix([]int{1})
+	if cachedMatrix == nil {
+		t.Fatal(cachedMatrix, "== nil")
+	}
+	if matrix.String() != cachedMatrix.String() {
+		t.Fatal(matrix.String(), "!=", cachedMatrix.String())
 	}
 }
 
@@ -93,5 +96,30 @@ func TestInsertInvertedMatrix(t *testing.T) {
 	err = tree.InsertInvertedMatrix([]int{0, 1}, matrix, 5)
 	if err != nil {
 		t.Fatalf("Failed inserting new Matrix : %s", err)
+	}
+}
+
+func TestDoubleInsertInvertedMatrix(t *testing.T) {
+	tree := newInversionTree(3, 2)
+
+	matrix, err := newMatrix(3, 3)
+	if err != nil {
+		t.Fatalf("Failed initializing new Matrix : %s", err)
+	}
+	err = tree.InsertInvertedMatrix([]int{1}, matrix, 5)
+	if err != nil {
+		t.Fatalf("Failed inserting new Matrix : %s", err)
+	}
+	err = tree.InsertInvertedMatrix([]int{1}, matrix, 5)
+	if err != nil {
+		t.Fatalf("Failed inserting new Matrix : %s", err)
+	}
+
+	cachedMatrix := tree.GetInvertedMatrix([]int{1})
+	if cachedMatrix == nil {
+		t.Fatal(cachedMatrix, "== nil")
+	}
+	if matrix.String() != cachedMatrix.String() {
+		t.Fatal(matrix.String(), "!=", cachedMatrix.String())
 	}
 }

--- a/reedsolomon.go
+++ b/reedsolomon.go
@@ -439,7 +439,10 @@ func (r reedSolomon) Reconstruct(shards [][]byte) error {
 
 		// Cache the inverted matrix in the tree for future use keyed on the
 		// indices of the invalid rows.
-		r.tree.InsertInvertedMatrix(invalidIndices, dataDecodeMatrix, r.Shards)
+		err = r.tree.InsertInvertedMatrix(invalidIndices, dataDecodeMatrix, r.Shards)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Re-create any data shards that were missing.

--- a/reedsolomon.go
+++ b/reedsolomon.go
@@ -133,12 +133,7 @@ func New(dataShards, parityShards int) (Encoder, error) {
 	// of the invalid rows of the data to reconstruct.
 	// The inversion root node will have the identity matrix as
 	// its inversion matrix because it implies there are no errors.
-	identity, _ := identityMatrix(dataShards)
-	r.inversionRoot = inversionNode{
-		matrix:   identity,
-		mutex:    sync.RWMutex{},
-		children: make([]*inversionNode, dataShards+parityShards),
-	}
+	r.inversionRoot = newInversionTree(dataShards, parityShards)
 
 	r.parity = make([][]byte, parityShards)
 	for i := range r.parity {

--- a/reedsolomon_test.go
+++ b/reedsolomon_test.go
@@ -412,6 +412,13 @@ func benchmarkReconstruct(b *testing.B, dataShards, parityShards, shardSize int)
 		if err != nil {
 			b.Fatal(err)
 		}
+		ok, err := r.Verify(shards)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if !ok {
+			b.Fatal("Verification failed")
+		}
 	}
 }
 
@@ -475,12 +482,19 @@ func benchmarkReconstructP(b *testing.B, dataShards, parityShards, shardSize int
 			b.Fatal(err)
 		}
 
-		corruptRandom(shards, dataShards, parityShards)
-
 		for pb.Next() {
+			corruptRandom(shards, dataShards, parityShards)
+
 			err = r.Reconstruct(shards)
 			if err != nil {
 				b.Fatal(err)
+			}
+			ok, err := r.Verify(shards)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if !ok {
+				b.Fatal("Verification failed")
 			}
 		}
 	})

--- a/reedsolomon_test.go
+++ b/reedsolomon_test.go
@@ -377,6 +377,150 @@ func BenchmarkVerify10x4x16M(b *testing.B) {
 	benchmarkVerify(b, 10, 4, 16*1024*1024)
 }
 
+func corruptRandom(shards [][]byte, dataShards, parityShards int) {
+	shardsToCorrupt := rand.Intn(parityShards)
+	for i := 1; i <= shardsToCorrupt; i++ {
+		shards[rand.Intn(dataShards+parityShards)] = nil
+	}
+}
+
+func benchmarkReconstruct(b *testing.B, dataShards, parityShards, shardSize int) {
+	r, err := New(dataShards, parityShards)
+	if err != nil {
+		b.Fatal(err)
+	}
+	shards := make([][]byte, parityShards+dataShards)
+	for s := range shards {
+		shards[s] = make([]byte, shardSize)
+	}
+
+	rand.Seed(0)
+	for s := 0; s < dataShards; s++ {
+		fillRandom(shards[s])
+	}
+	err = r.Encode(shards)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.SetBytes(int64(shardSize * dataShards))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		corruptRandom(shards, dataShards, parityShards)
+
+		err = r.Reconstruct(shards)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// Benchmark 10 data slices with 2 parity slices holding 10000 bytes each
+func BenchmarkReconstruct10x2x10000(b *testing.B) {
+	benchmarkReconstruct(b, 10, 2, 10000)
+}
+
+// Benchmark 50 data slices with 5 parity slices holding 100000 bytes each
+func BenchmarkReconstruct50x5x50000(b *testing.B) {
+	benchmarkReconstruct(b, 50, 5, 100000)
+}
+
+// Benchmark 10 data slices with 2 parity slices holding 1MB bytes each
+func BenchmarkReconstruct10x2x1M(b *testing.B) {
+	benchmarkReconstruct(b, 10, 2, 1024*1024)
+}
+
+// Benchmark 5 data slices with 2 parity slices holding 1MB bytes each
+func BenchmarkReconstruct5x2x1M(b *testing.B) {
+	benchmarkReconstruct(b, 5, 2, 1024*1024)
+}
+
+// Benchmark 10 data slices with 4 parity slices holding 1MB bytes each
+func BenchmarkReconstruct10x4x1M(b *testing.B) {
+	benchmarkReconstruct(b, 10, 4, 1024*1024)
+}
+
+// Benchmark 5 data slices with 2 parity slices holding 1MB bytes each
+func BenchmarkReconstruct50x20x1M(b *testing.B) {
+	benchmarkReconstruct(b, 50, 20, 1024*1024)
+}
+
+// Benchmark 10 data slices with 4 parity slices holding 16MB bytes each
+func BenchmarkReconstruct10x4x16M(b *testing.B) {
+	benchmarkReconstruct(b, 10, 4, 16*1024*1024)
+}
+
+func benchmarkReconstructP(b *testing.B, dataShards, parityShards, shardSize int) {
+	r, err := New(dataShards, parityShards)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.SetBytes(int64(shardSize * dataShards))
+	runtime.GOMAXPROCS(runtime.NumCPU())
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		shards := make([][]byte, parityShards+dataShards)
+		for s := range shards {
+			shards[s] = make([]byte, shardSize)
+		}
+
+		rand.Seed(0)
+		for s := 0; s < dataShards; s++ {
+			fillRandom(shards[s])
+		}
+		err = r.Encode(shards)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		corruptRandom(shards, dataShards, parityShards)
+
+		for pb.Next() {
+			err = r.Reconstruct(shards)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// Benchmark 10 data slices with 2 parity slices holding 10000 bytes each
+func BenchmarkReconstructP10x2x10000(b *testing.B) {
+	benchmarkReconstructP(b, 10, 2, 10000)
+}
+
+// Benchmark 50 data slices with 5 parity slices holding 100000 bytes each
+func BenchmarkReconstructP50x5x50000(b *testing.B) {
+	benchmarkReconstructP(b, 50, 5, 100000)
+}
+
+// Benchmark 10 data slices with 2 parity slices holding 1MB bytes each
+func BenchmarkReconstructP10x2x1M(b *testing.B) {
+	benchmarkReconstructP(b, 10, 2, 1024*1024)
+}
+
+// Benchmark 5 data slices with 2 parity slices holding 1MB bytes each
+func BenchmarkReconstructP5x2x1M(b *testing.B) {
+	benchmarkReconstructP(b, 5, 2, 1024*1024)
+}
+
+// Benchmark 10 data slices with 4 parity slices holding 1MB bytes each
+func BenchmarkReconstructP10x4x1M(b *testing.B) {
+	benchmarkReconstructP(b, 10, 4, 1024*1024)
+}
+
+// Benchmark 5 data slices with 2 parity slices holding 1MB bytes each
+func BenchmarkReconstructP50x20x1M(b *testing.B) {
+	benchmarkReconstructP(b, 50, 20, 1024*1024)
+}
+
+// Benchmark 10 data slices with 4 parity slices holding 16MB bytes each
+func BenchmarkReconstructP10x4x16M(b *testing.B) {
+	benchmarkReconstructP(b, 10, 4, 16*1024*1024)
+}
+
 func TestEncoderReconstruct(t *testing.T) {
 	// Create some sample data
 	var data = make([]byte, 250000)


### PR DESCRIPTION
Hello,

I worked on a similar erasure coding (albeit slower) Go library which you mention in your README [go-erasure](https://github.com/somethingnew2-0/go-erasure).  One thing that I noticed that was missing from your library was that when reconstructing shards, the inverse matrix is calculated every time.  

There are a finite number of these inverse matrices for each encoding scheme.  In fact, there are M choose N where M is the total number of shards and N is the number of data shards.  For example when there are 4 data shards and 2 parity shards that means there are 6 choose 4 inverse matrices possible or 6!/4!(6-4)! = 6!/(4!2!) = (6*5)/2 = 15 inverse matrices.

To speed up reconstruction, we can cache all those inverse matrices either ahead of time or lazily.  This PR takes the lazy-loaded approach in a thread-safe manner by inserting each inverse matrix into a tree when the inverse is calculated.  When looking up or inserting a matrix into the tree, it is keyed off of the indices of the missing/invalid rows or shards of the data we wish to reconstruct.  This means the inverse matrices aren't stored only at the leaves of the tree, but at every node and makes the tree much more compact.

I've added unit tests for tree and benchmark (including parallel benchmark tests) for the reconstruction code.

I hope you like it and will consider merging it.  Let me know if you want me to squash the commits and feedback is definitely welcome.

Best,
Peter C