### PR TITLE
allow slice reuse in Reconstruct

### DIFF
--- a/reedsolomon.go
+++ b/reedsolomon.go
@@ -351,6 +351,8 @@ func shardSize(shards [][]byte) int {
 //
 // The length of the array must be equal to Shards.
 // You indicate that a shard is missing by setting it to nil.
+// As a special case, you may pass a shard with len == 0 and cap >= shardSize.
+// This shard will be treated as missing, but its memory will be reused.
 //
 // If there are too few shards to reconstruct the missing
 // ones, ErrTooFewShards will be returned.
@@ -456,7 +458,12 @@ func (r reedSolomon) Reconstruct(shards [][]byte) error {
 
 	for iShard := 0; iShard < r.DataShards; iShard++ {
 		if len(shards[iShard]) == 0 {
-			shards[iShard] = make([]byte, shardSize)
+			if cap(shards[iShard]) >= shardSize {
+				// If the shard has sufficient capacity, reuse it.
+				shards[iShard] = shards[iShard][:shardSize]
+			} else {
+				shards[iShard] = make([]byte, shardSize)
+			}
 			outputs[outputCount] = shards[iShard]
 			matrixRows[outputCount] = dataDecodeMatrix[iShard]
 			outputCount++
@@ -473,7 +480,12 @@ func (r reedSolomon) Reconstruct(shards [][]byte) error {
 	outputCount = 0
 	for iShard := r.DataShards; iShard < r.Shards; iShard++ {
 		if len(shards[iShard]) == 0 {
-			shards[iShard] = make([]byte, shardSize)
+			if cap(shards[iShard]) >= shardSize {
+				// If the shard has sufficient capacity, reuse it.
+				shards[iShard] = shards[iShard][:shardSize]
+			} else {
+				shards[iShard] = make([]byte, shardSize)
+			}
 			outputs[outputCount] = shards[iShard]
 			matrixRows[outputCount] = r.parity[iShard-r.DataShards]
 			outputCount++


### PR DESCRIPTION
Fixes #43 

I reran benchmarks after modifying `corruptRandom` to reslice to `[:0]` instead of setting to `nil`, but the improvement was negligible:

Nil shards:
```
BenchmarkReconstruct10x2x10000-4    	   30000	     39085 ns/op	2558.49 MB/s
BenchmarkReconstruct50x5x50000-4    	    1000	   1259968 ns/op	3968.35 MB/s
BenchmarkReconstruct10x2x1M-4       	    1000	   1893583 ns/op	5537.52 MB/s
BenchmarkReconstruct5x2x1M-4        	    2000	   1102636 ns/op	4754.86 MB/s
BenchmarkReconstruct10x4x1M-4       	     500	   3171474 ns/op	3306.27 MB/s
BenchmarkReconstruct50x20x1M-4      	      30	  37866446 ns/op	1384.57 MB/s
BenchmarkReconstruct10x4x16M-4      	      20	  92926443 ns/op	1805.43 MB/s
```

Capped shards:
```
BenchmarkReconstruct10x2x10000-4    	   50000	     38953 ns/op	2567.15 MB/s
BenchmarkReconstruct50x5x50000-4    	    2000	   1369688 ns/op	3650.46 MB/s
BenchmarkReconstruct10x2x1M-4       	    1000	   1490076 ns/op	7037.06 MB/s
BenchmarkReconstruct5x2x1M-4        	    2000	    965926 ns/op	5427.82 MB/s
BenchmarkReconstruct10x4x1M-4       	     500	   2917212 ns/op	3594.45 MB/s
BenchmarkReconstruct50x20x1M-4      	      50	  29996012 ns/op	1747.86 MB/s
BenchmarkReconstruct10x4x16M-4      	      20	  92237318 ns/op	1818.92 MB/s
```