### PR TITLE
adjust minSplitSize to 64K

### DIFF
--- a/reedsolomon.go
+++ b/reedsolomon.go
@@ -218,8 +218,8 @@ func (r reedSolomon) codeSomeShards(matrixRows, inputs, outputs [][]byte, output
 }
 
 const (
-	minSplitSize  = 512 // min split size per goroutine
-	maxGoroutines = 50  // max goroutines number for encoding & decoding
+	minSplitSize  = 65536 // min split size per goroutine
+	maxGoroutines = 50    // max goroutines number for encoding & decoding
 )
 
 // Perform the same as codeSomeShards, but split the workload into


### PR DESCRIPTION
I'm using reedsolomon for UDP packet(<1500Bytes for each packet), I don't want multiple goroutines started for each packet I received, it's too expensive.  I think setting the minSplitSize to 64K will be appropriate.