### PR TITLE
Remove RunParallel test cases that are taking too much time (and misr…

### DIFF
--- a/reedsolomon_test.go
+++ b/reedsolomon_test.go
@@ -553,34 +553,9 @@ func BenchmarkReconstructP10x2x10000(b *testing.B) {
 	benchmarkReconstructP(b, 10, 2, 10000)
 }
 
-// Benchmark 50 data slices with 5 parity slices holding 100000 bytes each
-func BenchmarkReconstructP50x5x50000(b *testing.B) {
-	benchmarkReconstructP(b, 50, 5, 100000)
-}
-
-// Benchmark 10 data slices with 2 parity slices holding 1MB bytes each
-func BenchmarkReconstructP10x2x1M(b *testing.B) {
-	benchmarkReconstructP(b, 10, 2, 1024*1024)
-}
-
-// Benchmark 5 data slices with 2 parity slices holding 1MB bytes each
-func BenchmarkReconstructP5x2x1M(b *testing.B) {
-	benchmarkReconstructP(b, 5, 2, 1024*1024)
-}
-
-// Benchmark 10 data slices with 4 parity slices holding 1MB bytes each
-func BenchmarkReconstructP10x4x1M(b *testing.B) {
-	benchmarkReconstructP(b, 10, 4, 1024*1024)
-}
-
-// Benchmark 5 data slices with 2 parity slices holding 1MB bytes each
-func BenchmarkReconstructP50x20x1M(b *testing.B) {
-	benchmarkReconstructP(b, 50, 20, 1024*1024)
-}
-
-// Benchmark 10 data slices with 4 parity slices holding 16MB bytes each
-func BenchmarkReconstructP10x4x16M(b *testing.B) {
-	benchmarkReconstructP(b, 10, 4, 16*1024*1024)
+// Benchmark 10 data slices with 5 parity slices holding 20000 bytes each
+func BenchmarkReconstructP10x5x20000(b *testing.B) {
+       benchmarkReconstructP(b, 10, 5, 20000)
 }
 
 func TestEncoderReconstruct(t *testing.T) {


### PR DESCRIPTION
…eporting benchmarks)

When that 'individual' function that is run inside of RunParallel() starts taking too much time, the benchmark results will show incorrect values and take a lot of time to complete.
This in turn causes the overall benchmark testing to exceed 600 seconds at which point 'go test' aborts (fixes issue #49).