### PR TITLE
Allow 256 total shards

### DIFF
--- a/reedsolomon.go
+++ b/reedsolomon.go
@@ -97,7 +97,7 @@ var ErrMaxShardNum = errors.New("cannot create Encoder with more than 256 data+p
 // New creates a new encoder and initializes it to
 // the number of data shards and parity shards that
 // you want to use. You can reuse this encoder.
-// Note that the maximum number of data shards is 256.
+// Note that the maximum number of total shards is 256.
 // If no options are supplied, default options are used.
 func New(dataShards, parityShards int, opts ...Option) (Encoder, error) {
 	r := reedSolomon{

--- a/reedsolomon.go
+++ b/reedsolomon.go
@@ -92,7 +92,7 @@ var ErrInvShardNum = errors.New("cannot create Encoder with zero or less data/pa
 // ErrMaxShardNum will be returned by New, if you attempt to create
 // an Encoder where data and parity shards cannot be bigger than
 // Galois field GF(2^8) - 1.
-var ErrMaxShardNum = errors.New("cannot create Encoder with 255 or more data+parity shards")
+var ErrMaxShardNum = errors.New("cannot create Encoder with more than 256 data+parity shards")
 
 // New creates a new encoder and initializes it to
 // the number of data shards and parity shards that
@@ -114,7 +114,7 @@ func New(dataShards, parityShards int, opts ...Option) (Encoder, error) {
 		return nil, ErrInvShardNum
 	}
 
-	if dataShards+parityShards > 255 {
+	if dataShards+parityShards > 256 {
 		return nil, ErrMaxShardNum
 	}
 

--- a/reedsolomon.go
+++ b/reedsolomon.go
@@ -89,9 +89,9 @@ type reedSolomon struct {
 // an Encoder where either data or parity shards is zero or less.
 var ErrInvShardNum = errors.New("cannot create Encoder with zero or less data/parity shards")
 
-// ErrMaxShardNum will be returned by New, if you attempt to create
-// an Encoder where data and parity shards cannot be bigger than
-// Galois field GF(2^8) - 1.
+// ErrMaxShardNum will be returned by New, if you attempt to create an
+// Encoder where data and parity shards are bigger than the order of
+// GF(2^8).
 var ErrMaxShardNum = errors.New("cannot create Encoder with more than 256 data+parity shards")
 
 // New creates a new encoder and initializes it to

--- a/reedsolomon_test.go
+++ b/reedsolomon_test.go
@@ -743,11 +743,13 @@ func TestNew(t *testing.T) {
 		err          error
 	}{
 		{127, 127, nil},
+		{128, 128, nil},
+		{255, 1, nil},
 		{256, 256, ErrMaxShardNum},
 
 		{0, 1, ErrInvShardNum},
 		{1, 0, ErrInvShardNum},
-		{257, 1, ErrMaxShardNum},
+		{256, 1, ErrMaxShardNum},
 
 		// overflow causes r.Shards to be negative
 		{256, int(^uint(0) >> 1), errInvalidRowSize},


### PR DESCRIPTION
The upper limit for the total shard count is the field size. Also, this
matches JavaReedSolomon.