### PR TITLE
Optimize pure Go version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ go:
   - 1.9.x
   - 1.10.x
   - 1.11.x
+  - 1.12.x
   - master
 
 install:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ go get -u github.com/klauspost/reedsolomon
 
 # Changes
 
+## March 6, 2019
+
+The pure Go implementation is about 30% faster. Minor tweaks to assembler implementations.
+
 ## February 8, 2019
 
 AVX512 accelerated version added for Intel Skylake CPUs. This can give up to a 4x speed improvement as compared to AVX2. See [here](https://github.com/klauspost/reedsolomon#performance-on-avx512) for more details.

--- a/galoisAvx512_amd64.go
+++ b/galoisAvx512_amd64.go
@@ -98,7 +98,7 @@ func galMulAVX512Parallel82(in, out [][]byte, matrixRows [][]byte, inputOffset, 
 	for c := inputOffset; c < inputOffset+dimIn; c++ {
 		for iRow := outputOffset; iRow < outputOffset+dimOut82; iRow++ {
 			if c < len(matrixRows[iRow]) {
-				mt := mulTable[matrixRows[iRow][c]]
+				mt := mulTable[matrixRows[iRow][c]][:256]
 				for i := done; i < len(in[0]); i++ {
 					if c == 0 { // only set value for first input column
 						out[iRow][i] = mt[in[c][i]]
@@ -140,7 +140,7 @@ func galMulAVX512Parallel84(in, out [][]byte, matrixRows [][]byte, inputOffset, 
 	for c := inputOffset; c < inputOffset+dimIn; c++ {
 		for iRow := outputOffset; iRow < outputOffset+dimOut84; iRow++ {
 			if c < len(matrixRows[iRow]) {
-				mt := mulTable[matrixRows[iRow][c]]
+				mt := mulTable[matrixRows[iRow][c]][:256]
 				for i := done; i < len(in[0]); i++ {
 					if c == 0 { // only set value for first input column
 						out[iRow][i] = mt[in[c][i]]

--- a/galois_amd64.go
+++ b/galois_amd64.go
@@ -51,7 +51,7 @@ func galMulSlice(c byte, in, out []byte, o *options) {
 	}
 	remain := len(in) - done
 	if remain > 0 {
-		mt := mulTable[c]
+		mt := mulTable[c][:256]
 		for i := done; i < len(in); i++ {
 			out[i] = mt[in[i]]
 		}
@@ -69,7 +69,7 @@ func galMulSliceXor(c byte, in, out []byte, o *options) {
 	}
 	remain := len(in) - done
 	if remain > 0 {
-		mt := mulTable[c]
+		mt := mulTable[c][:256]
 		for i := done; i < len(in); i++ {
 			out[i] ^= mt[in[i]]
 		}

--- a/galois_arm64.go
+++ b/galois_arm64.go
@@ -20,7 +20,7 @@ func galMulSlice(c byte, in, out []byte, o *options) {
 
 	remain := len(in) - done
 	if remain > 0 {
-		mt := mulTable[c]
+		mt := mulTable[c][:256]
 		for i := done; i < len(in); i++ {
 			out[i] = mt[in[i]]
 		}
@@ -34,7 +34,7 @@ func galMulSliceXor(c byte, in, out []byte, o *options) {
 
 	remain := len(in) - done
 	if remain > 0 {
-		mt := mulTable[c]
+		mt := mulTable[c][:256]
 		for i := done; i < len(in); i++ {
 			out[i] ^= mt[in[i]]
 		}

--- a/galois_noasm.go
+++ b/galois_noasm.go
@@ -7,14 +7,16 @@
 package reedsolomon
 
 func galMulSlice(c byte, in, out []byte, o *options) {
-	mt := mulTable[c]
+	mt := mulTable[c][:256]
+	out = out[:len(in)]
 	for n, input := range in {
 		out[n] = mt[input]
 	}
 }
 
 func galMulSliceXor(c byte, in, out []byte, o *options) {
-	mt := mulTable[c]
+	mt := mulTable[c][:256]
+	out = out[:len(in)]
 	for n, input := range in {
 		out[n] ^= mt[input]
 	}
@@ -28,4 +30,5 @@ func sliceXor(in, out []byte, sse2 bool) {
 }
 
 func (r reedSolomon) codeSomeShardsAvx512(matrixRows, inputs, outputs [][]byte, outputCount, byteCount int) {
+	panic("unreachable")
 }

--- a/galois_ppc64le.go
+++ b/galois_ppc64le.go
@@ -38,7 +38,7 @@ func galMulSlice(c byte, in, out []byte, o *options) {
 	}
 	remain := len(in) - done
 	if remain > 0 {
-		mt := mulTable[c]
+		mt := mulTable[c][:256]
 		for i := done; i < len(in); i++ {
 			out[i] = mt[in[i]]
 		}
@@ -52,7 +52,7 @@ func galMulSliceXor(c byte, in, out []byte, o *options) {
 	}
 	remain := len(in) - done
 	if remain > 0 {
-		mt := mulTable[c]
+		mt := mulTable[c][:256]
 		for i := done; i < len(in); i++ {
 			out[i] ^= mt[in[i]]
 		}

--- a/reedsolomon.go
+++ b/reedsolomon.go
@@ -464,8 +464,8 @@ func (r reedSolomon) codeSomeShardsP(matrixRows, inputs, outputs [][]byte, outpu
 	if do < r.o.minSplitSize {
 		do = r.o.minSplitSize
 	}
-	// Make sizes divisible by 16
-	do = (do + 15) & (^15)
+	// Make sizes divisible by 32
+	do = (do + 31) & (^31)
 	start := 0
 	for start < byteCount {
 		if start+do > byteCount {
@@ -525,8 +525,8 @@ func (r reedSolomon) checkSomeShardsP(matrixRows, inputs, toCheck [][]byte, outp
 	if do < r.o.minSplitSize {
 		do = r.o.minSplitSize
 	}
-	// Make sizes divisible by 16
-	do = (do + 15) & (^15)
+	// Make sizes divisible by 32
+	do = (do + 31) & (^31)
 	start := 0
 	for start < byteCount {
 		if start+do > byteCount {


### PR DESCRIPTION
* Avoid dst bounds check when using noasm ~30% faster.
* Convert multiply table to a slice whenever used.
* Split on 32 byte boundaries instead of 16 byte.