### PR TITLE
Fixed upper bound check for data shard cli argument in example encode…

### DIFF
--- a/examples/simple-encoder.go
+++ b/examples/simple-encoder.go
@@ -67,8 +67,8 @@ func main() {
 		flag.Usage()
 		os.Exit(1)
 	}
-	if *dataShards > 257 {
-		fmt.Fprintf(os.Stderr, "Error: Too many data shards\n")
+	if (*dataShards + *parShards) > 256 {
+		fmt.Fprintf(os.Stderr, "Error: sum of data and parity shards cannot exceed 256\n")
 		os.Exit(1)
 	}
 	fname := args[0]
@@ -99,7 +99,7 @@ func main() {
 		outfn := fmt.Sprintf("%s.%d", file, i)
 
 		fmt.Println("Writing to", outfn)
-		err = ioutil.WriteFile(filepath.Join(dir, outfn), shard, os.ModePerm)
+		err = ioutil.WriteFile(filepath.Join(dir, outfn), shard, 0644)
 		checkErr(err)
 	}
 }

--- a/examples/stream-encoder.go
+++ b/examples/stream-encoder.go
@@ -68,8 +68,8 @@ func main() {
 		flag.Usage()
 		os.Exit(1)
 	}
-	if *dataShards > 257 {
-		fmt.Fprintf(os.Stderr, "Error: Too many data shards\n")
+	if (*dataShards + *parShards) > 256 {
+		fmt.Fprintf(os.Stderr, "Error: sum of data and parity shards cannot exceed 256\n")
 		os.Exit(1)
 	}
 	fname := args[0]


### PR DESCRIPTION
…rs and file permission issue.

This fixes issue #97 and additionally reduces the file permission bits on the ```simple-encoder.go```'s output files from ```0777``` to ```0644```. If there was a reason for making the output files world-executable, please let me know.