### PR TITLE
Split: Reduce memory allocation

### DIFF
--- a/reedsolomon.go
+++ b/reedsolomon.go
@@ -818,15 +818,26 @@ func (r reedSolomon) Split(data []byte) ([][]byte, error) {
 	}
 
 	// Only allocate memory if necessary
+	var padding []byte
 	if len(data) < (r.Shards * perShard) {
-		data = append(data, make([]byte, r.Shards*perShard-len(data))...)
+		// calculate maximum number of full shards in `data` slice
+		fullShards := len(data) / perShard
+		padding = make([]byte, r.Shards*perShard-perShard*fullShards)
+		copy(padding, data[perShard*fullShards:])
+		data = data[0 : perShard*fullShards]
 	}
 
 	// Split into equal-length shards.
 	dst := make([][]byte, r.Shards)
-	for i := range dst {
+	i := 0
+	for ; i < len(dst) && len(data) >= perShard; i++ {
 		dst[i] = data[:perShard]
 		data = data[perShard:]
+	}
+
+	for j := 0; i+j < len(dst); j++ {
+		dst[i+j] = padding[:perShard]
+		padding = padding[perShard:]
 	}
 
 	return dst, nil

--- a/reedsolomon.go
+++ b/reedsolomon.go
@@ -819,9 +819,7 @@ func (r reedSolomon) Split(data []byte) ([][]byte, error) {
 
 	// Only allocate memory if necessary
 	if len(data) < (r.Shards * perShard) {
-		// Pad data to r.Shards*perShard.
-		padding := make([]byte, (r.Shards*perShard)-len(data))
-		data = append(data, padding...)
+		data = append(data, make([]byte, r.Shards*perShard-len(data))...)
 	}
 
 	// Split into equal-length shards.

--- a/reedsolomon_test.go
+++ b/reedsolomon_test.go
@@ -1355,3 +1355,50 @@ func TestNew(t *testing.T) {
 		}
 	}
 }
+
+// Benchmark 10 data shards and 4 parity shards and 160MB data.
+func BenchmarkSplit10x4x160M(b *testing.B) {
+	benchmarkSplit(b, 10, 4, 160*1024*1024)
+}
+
+// Benchmark 5 data shards and 2 parity shards with 5MB data.
+func BenchmarkSplit5x2x5M(b *testing.B) {
+	benchmarkSplit(b, 5, 2, 5*1024*1024)
+}
+
+// Benchmark 1 data shards and 2 parity shards with 1MB data.
+func BenchmarkSplit10x2x1M(b *testing.B) {
+	benchmarkSplit(b, 10, 2, 1024*1024)
+}
+
+// Benchmark 10 data shards and 4 parity shards with 10MB data.
+func BenchmarkSplit10x4x10M(b *testing.B) {
+	benchmarkSplit(b, 10, 4, 10*1024*1024)
+}
+
+// Benchmark 50 data shards and 20 parity shards with 50MB data.
+func BenchmarkSplit50x20x50M(b *testing.B) {
+	benchmarkSplit(b, 50, 20, 50*1024*1024)
+}
+
+// Benchmark 17 data shards and 3 parity shards with 272MB data.
+func BenchmarkSplit17x3x272M(b *testing.B) {
+	benchmarkSplit(b, 17, 3, 272*1024*1024)
+}
+
+func benchmarkSplit(b *testing.B, shards, parity, dataSize int) {
+	r, err := New(shards, parity)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	data := make([]byte, dataSize)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err = r.Split(data)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
The following part of code has 2 memory allocation:
```go
if len(data) < (r.Shards * perShard) {
    // Pad data to r.Shards*perShard.
    padding := make([]byte, (r.Shards*perShard)-len(data))
    data = append(data, padding...)
}
```

1. `make([]byte, (r.Shards*perShard)-len(data))`
2. `append` function allocates new slice with `capacity = (len(data) + len(padding) + 1)*2` ( More details https://blog.golang.org/go-slices-usage-and-internals )

The following line of code is fixed the problem:
```go
data = append(data, make([]byte, r.Shards*perShard - len(data))...)
```
Because compiler specially optimize this case: https://github.com/golang/go/issues/21266


Old code benchmark:
```go
BenchmarkSplit10x4x160M-4   	      30	  54329722 ns/op	329253216 B/op	       3 allocs/op
BenchmarkSplit5x2x5M-4      	    1000	   1616534 ns/op	10289328 B/op	       3 allocs/op
BenchmarkSplit10x2x1M-4     	    5000	    212577 ns/op	 1524000 B/op	       3 allocs/op
BenchmarkSplit10x4x10M-4    	     500	   3085607 ns/op	20578657 B/op	       3 allocs/op
BenchmarkSplit50x20x50M-4   	     100	  16650049 ns/op	102893316 B/op	       3 allocs/op
BenchmarkSplit17x3x272M-4   	      20	  71213362 ns/op	406847972 B/op	       3 allocs/op
```

New code benchmark:
```
BenchmarkSplit10x4x160M-4   	      20	  50570930 ns/op	262144353 B/op	       2 allocs/op
BenchmarkSplit5x2x5M-4      	    2000	   1212313 ns/op	 8192176 B/op	       2 allocs/op
BenchmarkSplit10x2x1M-4     	   10000	    182420 ns/op	 1311008 B/op	       2 allocs/op
BenchmarkSplit10x4x10M-4    	     500	   2255361 ns/op	16384352 B/op	       2 allocs/op
BenchmarkSplit50x20x50M-4   	     100	  13558897 ns/op	81921792 B/op	       2 allocs/op
BenchmarkSplit17x3x272M-4   	      30	  64837941 ns/op	356516323 B/op	       2 allocs/op
```

Compare new and old
```
benchmark                     old ns/op     new ns/op     delta
BenchmarkSplit10x4x160M-4     54329722      50570930      -6.92%
BenchmarkSplit5x2x5M-4        1616534       1212313       -25.01%
BenchmarkSplit10x2x1M-4       212577        182420        -14.19%
BenchmarkSplit10x4x10M-4      3085607       2255361       -26.91%
BenchmarkSplit50x20x50M-4     16650049      13558897      -18.57%
BenchmarkSplit17x3x272M-4     71213362      64837941      -8.95%

benchmark                     old allocs     new allocs     delta
BenchmarkSplit10x4x160M-4     3              2              -33.33%
BenchmarkSplit5x2x5M-4        3              2              -33.33%
BenchmarkSplit10x2x1M-4       3              2              -33.33%
BenchmarkSplit10x4x10M-4      3              2              -33.33%
BenchmarkSplit50x20x50M-4     3              2              -33.33%
BenchmarkSplit17x3x272M-4     3              2              -33.33%

benchmark                     old bytes     new bytes     delta
BenchmarkSplit10x4x160M-4     329253216     262144353     -20.38%
BenchmarkSplit5x2x5M-4        10289328      8192176       -20.38%
BenchmarkSplit10x2x1M-4       1524000       1311008       -13.98%
BenchmarkSplit10x4x10M-4      20578657      16384352      -20.38%
BenchmarkSplit50x20x50M-4     102893316     81921792      -20.38%
BenchmarkSplit17x3x272M-4     406847972     356516323     -12.37%
```