### PR TITLE
limit capacity of shards to shard size

### DIFF
--- a/reedsolomon.go
+++ b/reedsolomon.go
@@ -835,12 +835,12 @@ func (r reedSolomon) Split(data []byte) ([][]byte, error) {
 	dst := make([][]byte, r.Shards)
 	i := 0
 	for ; i < len(dst) && len(data) >= perShard; i++ {
-		dst[i] = data[:perShard]
+		dst[i] = data[:perShard:perShard]
 		data = data[perShard:]
 	}
 
 	for j := 0; i+j < len(dst); j++ {
-		dst[i+j] = padding[:perShard]
+		dst[i+j] = padding[:perShard:perShard]
 		padding = padding[perShard:]
 	}
 


### PR DESCRIPTION
This commit limits the capacity (additionally
to the length) of each shard to the shard size.

Before this change the following code behaves in
an unexpected way:
```
shards := encoder.Split(buffer)
// ...
shards[0] = shards[0][:cap(shards[0])]
```

Instead of restoring the length of `shards[0]` to
the shard size, it assigns the entire memory of `buffer`
to `shards[0]`.