### PR TITLE
Use CPU to set minSplitSize

### DIFF
--- a/options.go
+++ b/options.go
@@ -20,7 +20,7 @@ type options struct {
 
 var defaultOptions = options{
 	maxGoroutines: 384,
-	minSplitSize:  1024,
+	minSplitSize:  -1,
 }
 
 func init() {
@@ -61,6 +61,7 @@ func WithAutoGoroutines(shardSize int) Option {
 }
 
 // WithMinSplitSize is the minimum encoding size in bytes per goroutine.
+// By default this parameter is determined by CPU cache characteristics.
 // See WithMaxGoroutines on how jobs are split.
 // If n <= 0, it is ignored.
 func WithMinSplitSize(n int) Option {

--- a/reedsolomon.go
+++ b/reedsolomon.go
@@ -270,6 +270,19 @@ func New(dataShards, parityShards int, opts ...Option) (Encoder, error) {
 		r.o.maxGoroutines = g
 	}
 
+	if r.o.minSplitSize <= 0 {
+		// Set minsplit as high as we can, but still have parity in L1.
+		cacheSize := cpuid.CPU.Cache.L1D
+		if cacheSize <= 0 {
+			cacheSize = 32 << 10
+		}
+		r.o.minSplitSize = cacheSize / (parityShards + 1)
+		// Min 1K
+		if r.o.minSplitSize < 1024 {
+			r.o.minSplitSize = 1024
+		}
+	}
+
 	// Inverted matrices are cached in a tree keyed by the indices
 	// of the invalid rows of the data to reconstruct.
 	// The inversion root node will have the identity matrix as


### PR DESCRIPTION
Use L1 cache size to set default split size.

Improves small block performance
```
benchmark                                 old MB/s      new MB/s      speedup
BenchmarkEncode10x2x10000-32              10860.74      19547.78      1.80x
BenchmarkVerify10x2x10000-32              5069.17       10488.04      2.07x
BenchmarkReconstruct10x2x10000-32         14243.36      61903.08      4.35x
BenchmarkReconstructData10x2x10000-32     21304.85      61961.95      2.91x
BenchmarkStreamEncode10x2x1M-32           1478.88       1746.02       1.18x
```