### PR TITLE
Avx512 parallel81

### DIFF
--- a/galoisAvx512_amd64.go
+++ b/galoisAvx512_amd64.go
@@ -10,6 +10,9 @@ package reedsolomon
 import "sync"
 
 //go:noescape
+func _galMulAVX512Parallel81(in, out [][]byte, matrix *[matrixSize81]byte, addTo bool)
+
+//go:noescape
 func _galMulAVX512Parallel82(in, out [][]byte, matrix *[matrixSize82]byte, addTo bool)
 
 //go:noescape
@@ -17,8 +20,10 @@ func _galMulAVX512Parallel84(in, out [][]byte, matrix *[matrixSize84]byte, addTo
 
 const (
 	dimIn        = 8                            // Number of input rows processed simultaneously
+	dimOut81     = 1                            // Number of output rows processed simultaneously for x1 routine
 	dimOut82     = 2                            // Number of output rows processed simultaneously for x2 routine
 	dimOut84     = 4                            // Number of output rows processed simultaneously for x4 routine
+	matrixSize81 = (16 + 16) * dimIn * dimOut81 // Dimension of slice of matrix coefficient passed into x1 routine
 	matrixSize82 = (16 + 16) * dimIn * dimOut82 // Dimension of slice of matrix coefficient passed into x2 routine
 	matrixSize84 = (16 + 16) * dimIn * dimOut84 // Dimension of slice of matrix coefficient passed into x4 routine
 )

--- a/reedsolomon_test.go
+++ b/reedsolomon_test.go
@@ -1483,3 +1483,7 @@ func BenchmarkParallel_20x10x05M(b *testing.B) { benchmarkParallel(b, 20, 10, 51
 func BenchmarkParallel_8x8x1M(b *testing.B)    { benchmarkParallel(b, 8, 8, 1<<20) }
 func BenchmarkParallel_8x8x8M(b *testing.B)    { benchmarkParallel(b, 8, 8, 8<<20) }
 func BenchmarkParallel_8x8x32M(b *testing.B)   { benchmarkParallel(b, 8, 8, 32<<20) }
+
+func BenchmarkParallel_8x3x1M(b *testing.B) { benchmarkParallel(b, 8, 3, 1<<20) }
+func BenchmarkParallel_8x4x1M(b *testing.B) { benchmarkParallel(b, 8, 4, 1<<20) }
+func BenchmarkParallel_8x5x1M(b *testing.B) { benchmarkParallel(b, 8, 5, 1<<20) }


### PR DESCRIPTION
AVX512 version handling (up to) 8 input rows in parallel to generate a single output row.

Can speed up cases with uneven parity significantly as per:

```
$ benchcmp loop.txt parallel81.txt 
benchmark                      old MB/s     new MB/s     speedup
BenchmarkParallel_8x3x1M-4     4445.49      14375.89     3.23x
BenchmarkParallel_8x4x1M-4     19074.16     19610.58     1.03x
BenchmarkParallel_8x5x1M-4     3008.53      11547.82     3.84x
```
