### PR TITLE
tests: Set full data size as number of bytes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/klauspost/reedsolomon
 
 go 1.14
 
-require (
-	github.com/klauspost/cpuid/v2 v2.0.1
-	github.com/stretchr/testify v1.6.1
-)
+require github.com/klauspost/cpuid/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,2 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/klauspost/cpuid/v2 v2.0.1 h1:lb04bBEJoAoV48eHs4Eq0UyhmJCkRSdIjQ3uS8WJRM4=
-github.com/klauspost/cpuid/v2 v2.0.1/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+github.com/klauspost/cpuid/v2 v2.0.2 h1:pd2FBxFydtPn2ywTLStbFg9CJKrojATnpeJWSP7Ys4k=
+github.com/klauspost/cpuid/v2 v2.0.2/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=

--- a/reedsolomon_test.go
+++ b/reedsolomon_test.go
@@ -761,7 +761,7 @@ func benchmarkEncode(b *testing.B, dataShards, parityShards, shardSize int) {
 		fillRandom(shards[s])
 	}
 
-	b.SetBytes(int64(shardSize * dataShards))
+	b.SetBytes(int64(shardSize * (dataShards + parityShards)))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		err = r.Encode(shards)
@@ -853,7 +853,7 @@ func benchmarkVerify(b *testing.B, dataShards, parityShards, shardSize int) {
 		b.Fatal(err)
 	}
 
-	b.SetBytes(int64(shardSize * dataShards))
+	b.SetBytes(int64(shardSize * (dataShards + parityShards)))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err = r.Verify(shards)
@@ -925,7 +925,7 @@ func benchmarkReconstruct(b *testing.B, dataShards, parityShards, shardSize int)
 		b.Fatal(err)
 	}
 
-	b.SetBytes(int64(shardSize * dataShards))
+	b.SetBytes(int64(shardSize * (dataShards + parityShards)))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		corruptRandom(shards, dataShards, parityShards)
@@ -999,7 +999,7 @@ func benchmarkReconstructData(b *testing.B, dataShards, parityShards, shardSize 
 		b.Fatal(err)
 	}
 
-	b.SetBytes(int64(shardSize * dataShards))
+	b.SetBytes(int64(shardSize * (dataShards + parityShards)))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		corruptRandomData(shards, dataShards, parityShards)
@@ -1052,7 +1052,7 @@ func benchmarkReconstructP(b *testing.B, dataShards, parityShards, shardSize int
 		b.Fatal(err)
 	}
 
-	b.SetBytes(int64(shardSize * dataShards))
+	b.SetBytes(int64(shardSize * (dataShards + parityShards)))
 	b.ResetTimer()
 
 	b.RunParallel(func(pb *testing.PB) {
@@ -1069,7 +1069,7 @@ func benchmarkReconstructP(b *testing.B, dataShards, parityShards, shardSize int
 		if err != nil {
 			b.Fatal(err)
 		}
-
+		b.ResetTimer()
 		for pb.Next() {
 			corruptRandom(shards, dataShards, parityShards)
 
@@ -1521,7 +1521,7 @@ func benchmarkParallel(b *testing.B, dataShards, parityShards, shardSize int) {
 		shardsCh <- shards
 	}
 
-	b.SetBytes(int64(shardSize * dataShards))
+	b.SetBytes(int64(shardSize * (dataShards + parityShards)))
 	b.SetParallelism(c)
 	b.ReportAllocs()
 	b.ResetTimer()


### PR DESCRIPTION
Use total data size (data+parity) as benchmark sizes for more consistent benchmarks.