### PR TITLE
Fix build tags for gccgo

### DIFF
--- a/galoisAvx512_amd64.s
+++ b/galoisAvx512_amd64.s
@@ -1,4 +1,6 @@
-//+build !noasm !appengine !gccgo
+//+build !noasm
+//+build !appengine
+//+build !gccgo
 
 // Copyright 2015, Klaus Post, see LICENSE for details.
 // Copyright 2019, Minio, Inc.

--- a/galois_amd64.s
+++ b/galois_amd64.s
@@ -1,4 +1,6 @@
-//+build !noasm !appengine !gccgo
+//+build !noasm
+//+build !appengine
+//+build !gccgo
 
 // Copyright 2015, Klaus Post, see LICENSE for details.
 

--- a/galois_arm64.s
+++ b/galois_arm64.s
@@ -1,4 +1,6 @@
-//+build !noasm !appengine !gccgo
+//+build !noasm
+//+build !appengine
+//+build !gccgo
 
 // Copyright 2015, Klaus Post, see LICENSE for details.
 // Copyright 2017, Minio, Inc.

--- a/galois_ppc64le.s
+++ b/galois_ppc64le.s
@@ -1,4 +1,6 @@
-//+build !noasm !appengine !gccgo
+//+build !noasm
+//+build !appengine
+//+build !gccgo
 
 // Copyright 2015, Klaus Post, see LICENSE for details.
 // Copyright 2018, Minio, Inc.


### PR DESCRIPTION
According to [document of build tags](https://golang.org/cmd/go/#hdr-Build_constraints), `space` equals to OR, `comma` & `newline` equals to AND. So the logic of build tags of gccgo is wrong, causing errors when using gccgo.