### PR TITLE
Add Leopard bitfield

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,28 +409,28 @@ For Cauchy matrix the inversion cache is disabled for a more "fair" test.
 Speed is total shard size for each operation. Data shard throughput is speed/2.
 AVX2 is used.
 
-| Encoder      | Shards      | Encode        | Reconstruct  |
-|--------------|-------------|---------------|--------------|
-| Cauchy       | 4+4         | 23076.83 MB/s | 3048.86 MB/s |
-| Cauchy       | 8+8         | 15206.87 MB/s | 3041.99 MB/s |
-| Cauchy       | 16+16       | 7427.47 MB/s  | 1384.58 MB/s |
-| Cauchy       | 32+32       | 3785.64 MB/s  | 557.60 MB/s  |
-| Cauchy       | 64+64       | 1911.93 MB/s  | 160.54 MB/s  |
-| Cauchy       | 128+128     | 963.83 MB/s   | 42.81 MB/s   |
-| Leopard GF16 | 4+4         | 18468.32 MB/s | 10.45 MB/s   |
-| Leopard GF16 | 8+8         | 10293.79 MB/s | 20.83 MB/s   |
-| Leopard GF16 | 16+16       | 12386.04 MB/s | 40.80 MB/s   |
-| Leopard GF16 | 32+32       | 7347.35 MB/s  | 81.15 MB/s   |
-| Leopard GF16 | 64+64       | 8299.63 MB/s  | 150.47 MB/s  |
-| Leopard GF16 | 128+128     | 5629.04 MB/s  | 278.84 MB/s  |
-| Leopard GF16 | 256+256     | 6158.66 MB/s  | 454.14 MB/s  |
-| Leopard GF16 | 512+512     | 4418.58 MB/s  | 685.75 MB/s  |
-| Leopard GF16 | 1024+1024   | 4778.05 MB/s  | 814.51 MB/s  |
-| Leopard GF16 | 2048+2048   | 3417.05 MB/s  | 911.64 MB/s  |
-| Leopard GF16 | 4096+4096   | 3209.41 MB/s  | 729.13 MB/s  |
-| Leopard GF16 | 8192+8192   | 2034.11 MB/s  | 604.52 MB/s  |
-| Leopard GF16 | 16384+16384 | 1525.88 MB/s  | 486.74 MB/s  |
-| Leopard GF16 | 32768+32768 | 1138.67 MB/s  | 482.81 MB/s  |
+| Encoder      | Shards      | Encode        | Recover All  | Recover One  |
+|--------------|-------------|---------------|--------------|--------------|
+| Cauchy       | 4+4         | 23076.83 MB/s | 3048.86 MB/s | 5620.84 MB/s |
+| Cauchy       | 8+8         | 15206.87 MB/s | 3041.99 MB/s | 7173.71 MB/s |
+| Cauchy       | 16+16       | 7427.47 MB/s  | 1384.58 MB/s | 6343.85 MB/s |
+| Cauchy       | 32+32       | 3785.64 MB/s  | 557.60 MB/s  | 4660.27 MB/s |
+| Cauchy       | 64+64       | 1911.93 MB/s  | 160.54 MB/s  | 2864.63 MB/s |
+| Cauchy       | 128+128     | 963.83 MB/s   | 42.81 MB/s   | 1597.93 MB/s |
+| Leopard GF16 | 4+4         | 18468.32 MB/s | 10.45 MB/s   | 10.30 MB/s   |
+| Leopard GF16 | 8+8         | 10293.79 MB/s | 20.83 MB/s   | 20.51 MB/s   |
+| Leopard GF16 | 16+16       | 12386.04 MB/s | 40.80 MB/s   | 40.47 MB/s   |
+| Leopard GF16 | 32+32       | 7347.35 MB/s  | 81.15 MB/s   | 79.80 MB/s   |
+| Leopard GF16 | 64+64       | 8299.63 MB/s  | 150.47 MB/s  | 154.15 MB/s  |
+| Leopard GF16 | 128+128     | 5629.04 MB/s  | 278.84 MB/s  | 289.15 MB/s  |
+| Leopard GF16 | 256+256     | 6158.66 MB/s  | 454.14 MB/s  | 506.70 MB/s  |
+| Leopard GF16 | 512+512     | 4418.58 MB/s  | 685.75 MB/s  | 801.63 MB/s  |
+| Leopard GF16 | 1024+1024   | 4778.05 MB/s  | 814.51 MB/s  | 1080.19 MB/s |
+| Leopard GF16 | 2048+2048   | 3417.05 MB/s  | 911.64 MB/s  | 1179.48 MB/s |
+| Leopard GF16 | 4096+4096   | 3209.41 MB/s  | 729.13 MB/s  | 1135.06 MB/s |
+| Leopard GF16 | 8192+8192   | 2034.11 MB/s  | 604.52 MB/s  | 842.13 MB/s  |
+| Leopard GF16 | 16384+16384 | 1525.88 MB/s  | 486.74 MB/s  | 750.01 MB/s  |
+| Leopard GF16 | 32768+32768 | 1138.67 MB/s  | 482.81 MB/s  | 712.73 MB/s  |
 
 "Traditional" encoding is faster until somewhere between 16 and 32 shards.
 Leopard provides fast encoding in all cases, but shows a significant overhead for reconstruction.

--- a/leopard.go
+++ b/leopard.go
@@ -1089,13 +1089,13 @@ func (e *errorBitfield) isNeededFn(mipLevel int) func(bit int) bool {
 		w := e.BigWords[mipLevel-6][:]
 		return func(bit int) bool {
 			bit /= 64
-			return 0 != (w[bit/64] & (uint64(1) << (bit % 64)))
+			return 0 != (w[bit/64] & (uint64(1) << (bit & 63)))
 		}
 	}
 	if mipLevel > 0 {
 		w := e.Words[mipLevel-1][:]
 		return func(bit int) bool {
-			return 0 != (w[bit/64] & (uint64(1) << (bit % 64)))
+			return 0 != (w[bit/64] & (uint64(1) << (bit & 63)))
 		}
 	}
 	return nil

--- a/reedsolomon_test.go
+++ b/reedsolomon_test.go
@@ -1107,7 +1107,7 @@ func benchmarkEncode(b *testing.B, dataShards, parityShards, shardSize int, opts
 	}
 }
 
-func benchmarkDecode(b *testing.B, dataShards, parityShards, shardSize int, opts ...Option) {
+func benchmarkDecode(b *testing.B, dataShards, parityShards, shardSize, deleteShards int, opts ...Option) {
 	opts = append(testOptions(WithAutoGoroutines(shardSize)), opts...)
 	r, err := New(dataShards, parityShards, opts...)
 	if err != nil {
@@ -1130,7 +1130,7 @@ func benchmarkDecode(b *testing.B, dataShards, parityShards, shardSize int, opts
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		// Clear maximum number of data shards.
-		for s := 0; s < parityShards; s++ {
+		for s := 0; s < deleteShards; s++ {
 			shards[s] = nil
 		}
 
@@ -1176,11 +1176,17 @@ func BenchmarkDecode1K(b *testing.B) {
 		b.Run(fmt.Sprintf("%v+%v", shards, shards), func(b *testing.B) {
 			if shards*2 <= 256 {
 				b.Run(fmt.Sprint("cauchy"), func(b *testing.B) {
-					benchmarkDecode(b, shards, shards, 1024, WithCauchyMatrix(), WithInversionCache(false))
+					benchmarkDecode(b, shards, shards, 1024, shards, WithCauchyMatrix(), WithInversionCache(false))
+				})
+				b.Run(fmt.Sprint("cauchy-single"), func(b *testing.B) {
+					benchmarkDecode(b, shards, shards, 1024, 1, WithCauchyMatrix(), WithInversionCache(false))
 				})
 			}
 			b.Run(fmt.Sprint("leopard-gf16"), func(b *testing.B) {
-				benchmarkDecode(b, shards, shards, 1024, WithLeopardGF16(true))
+				benchmarkDecode(b, shards, shards, 1024, shards, WithLeopardGF16(true))
+			})
+			b.Run(fmt.Sprint("leopard-gf16-single"), func(b *testing.B) {
+				benchmarkDecode(b, shards, shards, 1024, 1, WithLeopardGF16(true))
 			})
 		})
 	}


### PR DESCRIPTION
Use bitfields for progressive reconstruction.

For now only enabled when less than a fourth of parity shards are missing.
