### PR TITLE
Add inversion cache for leopard GF8

### DIFF
--- a/options.go
+++ b/options.go
@@ -21,6 +21,7 @@ type options struct {
 	useCauchy                             bool
 	fastOneParity                         bool
 	inversionCache                        bool
+	forcedInversionCache                  bool
 	customMatrix                          [][]byte
 	withLeopard                           leopardMode
 
@@ -130,10 +131,11 @@ func WithConcurrentStreamWrites(enabled bool) Option {
 
 // WithInversionCache allows to control the inversion cache.
 // This will cache reconstruction matrices so they can be reused.
-// Enabled by default.
+// Enabled by default, or <= 64 shards for Leopard encoding.
 func WithInversionCache(enabled bool) Option {
 	return func(o *options) {
 		o.inversionCache = enabled
+		o.forcedInversionCache = true
 	}
 }
 

--- a/reedsolomon_test.go
+++ b/reedsolomon_test.go
@@ -1205,8 +1205,14 @@ func BenchmarkDecode1K(b *testing.B) {
 				b.Run(fmt.Sprint("leopard-gf8"), func(b *testing.B) {
 					benchmarkDecode(b, shards, shards, 1024, shards, WithLeopardGF(true), WithInversionCache(false))
 				})
+				b.Run(fmt.Sprint("leopard-gf8-inv"), func(b *testing.B) {
+					benchmarkDecode(b, shards, shards, 1024, shards, WithLeopardGF(true), WithInversionCache(true))
+				})
 				b.Run(fmt.Sprint("leopard-gf8-single"), func(b *testing.B) {
 					benchmarkDecode(b, shards, shards, 1024, 1, WithLeopardGF(true), WithInversionCache(false))
+				})
+				b.Run(fmt.Sprint("leopard-gf8-single-inv"), func(b *testing.B) {
+					benchmarkDecode(b, shards, shards, 1024, 1, WithLeopardGF(true), WithInversionCache(true))
 				})
 			}
 			b.Run(fmt.Sprint("leopard-gf16"), func(b *testing.B) {


### PR DESCRIPTION
Also adds bitfield usage.

Inversion cache is automatically enabled for <= 64 total shards, since it adds little value above that.

Bits are used for bigger payloads (>=64KB)

GF8 times:

```
BenchmarkDecode1K
BenchmarkDecode1K/4+4
BenchmarkDecode1K/4+4/cauchy
BenchmarkDecode1K/4+4/cauchy-32  	  454539	      2603 ns/op	3146.70 MB/s	    4968 B/op	      32 allocs/op
BenchmarkDecode1K/4+4/cauchy-single
BenchmarkDecode1K/4+4/cauchy-single-32         	  823434	      1467 ns/op	5583.21 MB/s	    1843 B/op	      27 allocs/op
BenchmarkDecode1K/4+4/leopard-gf8
BenchmarkDecode1K/4+4/leopard-gf8-32           	  260366	      4513 ns/op	1815.32 MB/s	    4131 B/op	       5 allocs/op
BenchmarkDecode1K/4+4/leopard-gf8-inv
BenchmarkDecode1K/4+4/leopard-gf8-inv-32       	  444894	      2643 ns/op	3099.06 MB/s	    4126 B/op	       5 allocs/op
BenchmarkDecode1K/4+4/leopard-gf8-single
BenchmarkDecode1K/4+4/leopard-gf8-single-32    	  286162	      3889 ns/op	2106.36 MB/s	    1051 B/op	       2 allocs/op
BenchmarkDecode1K/4+4/leopard-gf8-single-inv
BenchmarkDecode1K/4+4/leopard-gf8-single-inv-32         	  599784	      2000 ns/op	4096.78 MB/s	    1049 B/op	       2 allocs/op
BenchmarkDecode1K/8+8
BenchmarkDecode1K/8+8/cauchy
BenchmarkDecode1K/8+8/cauchy-32                         	  185533	      6432 ns/op	2547.34 MB/s	   10094 B/op	      53 allocs/op
BenchmarkDecode1K/8+8/cauchy-single
BenchmarkDecode1K/8+8/cauchy-single-32                  	  472734	      2558 ns/op	6404.79 MB/s	    2793 B/op	      43 allocs/op
BenchmarkDecode1K/8+8/leopard-gf8
BenchmarkDecode1K/8+8/leopard-gf8-32                    	  157758	      7433 ns/op	2204.28 MB/s	    8244 B/op	       9 allocs/op
BenchmarkDecode1K/8+8/leopard-gf8-inv
BenchmarkDecode1K/8+8/leopard-gf8-inv-32                	  206976	      5600 ns/op	2925.92 MB/s	    8232 B/op	       9 allocs/op
BenchmarkDecode1K/8+8/leopard-gf8-single
BenchmarkDecode1K/8+8/leopard-gf8-single-32             	  193160	      6154 ns/op	2662.24 MB/s	    1052 B/op	       2 allocs/op
BenchmarkDecode1K/8+8/leopard-gf8-single-inv
BenchmarkDecode1K/8+8/leopard-gf8-single-inv-32         	  294296	      4133 ns/op	3964.00 MB/s	    1049 B/op	       2 allocs/op
BenchmarkDecode1K/16+16
BenchmarkDecode1K/16+16/cauchy
BenchmarkDecode1K/16+16/cauchy-32                       	   49598	     23960 ns/op	1367.62 MB/s	   20921 B/op	      94 allocs/op
BenchmarkDecode1K/16+16/cauchy-single
BenchmarkDecode1K/16+16/cauchy-single-32                	  210790	      5855 ns/op	5596.31 MB/s	    5201 B/op	      75 allocs/op
BenchmarkDecode1K/16+16/leopard-gf8
BenchmarkDecode1K/16+16/leopard-gf8-32                  	   74860	     15911 ns/op	2059.47 MB/s	   16477 B/op	      17 allocs/op
BenchmarkDecode1K/16+16/leopard-gf8-inv
BenchmarkDecode1K/16+16/leopard-gf8-inv-32              	   85515	     14073 ns/op	2328.40 MB/s	   16445 B/op	      17 allocs/op
BenchmarkDecode1K/16+16/leopard-gf8-single
BenchmarkDecode1K/16+16/leopard-gf8-single-32           	   95612	     12454 ns/op	2631.06 MB/s	    1052 B/op	       2 allocs/op
BenchmarkDecode1K/16+16/leopard-gf8-single-inv
BenchmarkDecode1K/16+16/leopard-gf8-single-inv-32       	  113343	     10536 ns/op	3110.22 MB/s	    1049 B/op	       2 allocs/op
BenchmarkDecode1K/32+32
BenchmarkDecode1K/32+32/cauchy
BenchmarkDecode1K/32+32/cauchy-32                       	    9307	    125788 ns/op	 521.00 MB/s	   45212 B/op	     175 allocs/op
BenchmarkDecode1K/32+32/cauchy-single
BenchmarkDecode1K/32+32/cauchy-single-32                	   75178	     15876 ns/op	4127.96 MB/s	   12272 B/op	     139 allocs/op
BenchmarkDecode1K/32+32/leopard-gf8
BenchmarkDecode1K/32+32/leopard-gf8-32                  	   37992	     32037 ns/op	2045.61 MB/s	   32969 B/op	      33 allocs/op
BenchmarkDecode1K/32+32/leopard-gf8-inv
BenchmarkDecode1K/32+32/leopard-gf8-inv-32              	   39867	     30236 ns/op	2167.50 MB/s	   32887 B/op	      33 allocs/op
BenchmarkDecode1K/32+32/leopard-gf8-single
BenchmarkDecode1K/32+32/leopard-gf8-single-32           	   58910	     20348 ns/op	3220.75 MB/s	    1052 B/op	       2 allocs/op
BenchmarkDecode1K/32+32/leopard-gf8-single-inv
BenchmarkDecode1K/32+32/leopard-gf8-single-inv-32       	   58536	     20429 ns/op	3207.96 MB/s	    1287 B/op	       3 allocs/op
BenchmarkDecode1K/64+64
BenchmarkDecode1K/64+64/cauchy
BenchmarkDecode1K/64+64/cauchy-32                       	    1407	    846808 ns/op	 154.78 MB/s	  105372 B/op	     336 allocs/op
BenchmarkDecode1K/64+64/cauchy-single
BenchmarkDecode1K/64+64/cauchy-single-32                	   22172	     53871 ns/op	2433.05 MB/s	   38656 B/op	     267 allocs/op
BenchmarkDecode1K/64+64/leopard-gf8
BenchmarkDecode1K/64+64/leopard-gf8-32                  	   16118	     75326 ns/op	1740.06 MB/s	   66038 B/op	      65 allocs/op
BenchmarkDecode1K/64+64/leopard-gf8-inv
BenchmarkDecode1K/64+64/leopard-gf8-inv-32              	   16600	     72114 ns/op	1817.58 MB/s	   65904 B/op	      65 allocs/op
BenchmarkDecode1K/64+64/leopard-gf8-single
BenchmarkDecode1K/64+64/leopard-gf8-single-32           	   28059	     43286 ns/op	3028.08 MB/s	    1054 B/op	       2 allocs/op
BenchmarkDecode1K/64+64/leopard-gf8-single-inv
BenchmarkDecode1K/64+64/leopard-gf8-single-inv-32       	   27764	     42809 ns/op	3061.81 MB/s	    1302 B/op	       3 allocs/op
BenchmarkDecode1K/128+128
BenchmarkDecode1K/128+128/cauchy
BenchmarkDecode1K/128+128/cauchy-32                     	     193	   6161499 ns/op	  42.55 MB/s	  335935 B/op	     657 allocs/op
BenchmarkDecode1K/128+128/cauchy-single
BenchmarkDecode1K/128+128/cauchy-single-32              	    5601	    197178 ns/op	1329.48 MB/s	  149507 B/op	     523 allocs/op
BenchmarkDecode1K/128+128/leopard-gf8
BenchmarkDecode1K/128+128/leopard-gf8-32                	    7058	    161310 ns/op	1625.10 MB/s	  131929 B/op	     129 allocs/op
BenchmarkDecode1K/128+128/leopard-gf8-inv
BenchmarkDecode1K/128+128/leopard-gf8-inv-32            	    7023	    159225 ns/op	1646.37 MB/s	  131971 B/op	     129 allocs/op
BenchmarkDecode1K/128+128/leopard-gf8-single
BenchmarkDecode1K/128+128/leopard-gf8-single-32         	   12648	     93179 ns/op	2813.34 MB/s	    1049 B/op	       2 allocs/op
BenchmarkDecode1K/128+128/leopard-gf8-single-inv
BenchmarkDecode1K/128+128/leopard-gf8-single-inv-32     	   12860	     93119 ns/op	2815.15 MB/s	    1294 B/op	       3 allocs/op
PASS
```