### PR TITLE
Split leopard gf8 input

### DIFF
--- a/reedsolomon_test.go
+++ b/reedsolomon_test.go
@@ -1387,8 +1387,10 @@ func corruptRandom(shards [][]byte, dataShards, parityShards int) {
 	}
 }
 
-func benchmarkReconstruct(b *testing.B, dataShards, parityShards, shardSize int) {
-	r, err := New(dataShards, parityShards, testOptions(WithAutoGoroutines(shardSize))...)
+func benchmarkReconstruct(b *testing.B, dataShards, parityShards, shardSize int, opts ...Option) {
+	o := []Option{WithAutoGoroutines(shardSize)}
+	o = append(o, opts...)
+	r, err := New(dataShards, parityShards, testOptions(o...)...)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -1455,6 +1457,11 @@ func BenchmarkReconstruct10x4x1M(b *testing.B) {
 // Benchmark 5 data slices with 2 parity slices holding 1MB bytes each
 func BenchmarkReconstruct50x20x1M(b *testing.B) {
 	benchmarkReconstruct(b, 50, 20, 1024*1024)
+}
+
+// Benchmark 5 data slices with 2 parity slices holding 1MB bytes each
+func BenchmarkReconstructLeopard50x20x1M(b *testing.B) {
+	benchmarkReconstruct(b, 50, 20, 1024*1024, WithLeopardGF(true), WithInversionCache(true))
 }
 
 // Benchmark 10 data slices with 4 parity slices holding 16MB bytes each


### PR DESCRIPTION
Split large input into 8KB slices for en/decodes for cache locality.

Mainly a benefit for large encodes:

```
BenchmarkEncodeLeopard50x20x1M-32    	      49	  23850959 ns/op	3077.46 MB/s	      24 B/op	       1 allocs/op
BenchmarkEncodeLeopard50x20x1M-32    	     100	  11016534 ns/op	6662.74 MB/s	    1816 B/op	       2 allocs/op

BenchmarkReconstructLeopard50x20x1M-32    	      12	  94149175 ns/op	 779.62 MB/s	11185758 B/op	      13 allocs/op
BenchmarkReconstructLeopard50x20x1M-32    	      39	  34056205 ns/op	2155.27 MB/s	   29109 B/op	       3 allocs/op
```