### PR TITLE
Disable broken Leopard GF8 GFNI code

### DIFF
--- a/galois_amd64.go
+++ b/galois_amd64.go
@@ -233,7 +233,7 @@ func ifftDIT48(work [][]byte, dist int, log_m01, log_m23, log_m02 ffe8, o *optio
 		return
 	}
 
-	if o.useGFNI {
+	if false && o.useGFNI {
 		// Note that these currently require that length is multiple of 64.
 		t01 := gf2p811dMulMatrices[log_m01]
 		t23 := gf2p811dMulMatrices[log_m23]
@@ -388,7 +388,7 @@ func fftDIT48(work [][]byte, dist int, log_m01, log_m23, log_m02 ffe8, o *option
 		return
 	}
 
-	if o.useGFNI {
+	if false && o.useGFNI {
 		t01 := gf2p811dMulMatrices[log_m01]
 		t23 := gf2p811dMulMatrices[log_m23]
 		t02 := gf2p811dMulMatrices[log_m02]


### PR DESCRIPTION
GFNI is broken on Leopard GF8 (enabled with `WithLeopardGF(true)`). Disable it until fixed.