### PR TITLE
updated simple-en/decoder to use shard headers.

### DIFF
--- a/examples/test.sh
+++ b/examples/test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+mkdir test
+dd if=/dev/random of=test/1 bs=16384 count=16384
+go run ./simple-encoder.go ./test/1
+cp test/1.0 test/1.0.orig # keep a good copy
+echo
+echo "testing wrong length"
+echo " " >> test/1.0
+go run ./simple-decoder.go ./test/1 | head -4
+echo
+
+cp -f test/1.0.orig test/1.0
+echo "testing broken magic file"
+printf '\x31\xc0\xc3' | dd of=test/1.0 bs=1 seek=0 count=3 conv=notrunc 2> /dev/null
+go run ./simple-decoder.go ./test/1 | head -5
+echo
+
+cp -f test/1.0.orig test/1.0
+echo "testing broken sha256 checksum"
+printf '\x31\xc0\xc3' | dd of=test/1.0 bs=1 seek=100 count=3 conv=notrunc 2> /dev/null
+go run ./simple-decoder.go ./test/1 | head -6
+echo
+
+cp -f test/1.5 test/1.0
+echo "testing broken shards in wrong order"
+go run ./simple-decoder.go ./test/1 | head -7
+
+


### PR DESCRIPTION
For the examples each shard gets a header for magic value, shard number, maxShard, size, and sha256 checksum.

Simple-encode adds the header and simple-decode checks these to help the user know if any shared has the wrong magic value, the wrong size, the wrong checksum (corrupted file), and the wrong order.  By detecting these it's MUCH easier to decode since corrupted shards are automatically excluded.  I wrote a test.sh (included) that corrupts shards (length, magic, checksum, and order) and decodes to show what happens.

I'd also suggest (this is NOT in the pull request) that enc.split and enc.Encode include an optional argument called header, which is prepended to each shard.  Similarly enc.Decode should take an optional argument to skip the header (number of bytes)  Thoughts?  

Or maybe reedsolomon should not include file I/O, and just include some examples?

BTW, ioutil is deprecated: As of Go 1.16.

