### PR TITLE
Remove dead code in fwht

### DIFF
--- a/leopard.go
+++ b/leopard.go
@@ -451,13 +451,13 @@ func (r *leopardFF16) reconstruct(shards [][]byte, recoverAll bool) error {
 	}
 
 	// Evaluate error locator polynomial
-	fwht(&errLocs, order, m+r.dataShards)
+	fwht(&errLocs, m+r.dataShards)
 
 	for i := 0; i < order; i++ {
 		errLocs[i] = ffe((uint(errLocs[i]) * uint(logWalsh[i])) % modulus)
 	}
 
-	fwht(&errLocs, order, order)
+	fwht(&errLocs, order)
 
 	var work [][]byte
 	if w, ok := r.workPool.Get().([][]byte); ok {
@@ -863,11 +863,11 @@ func ceilPow2(n int) int {
 // Decimation in time (DIT) Fast Walsh-Hadamard Transform
 // Unrolls pairs of layers to perform cross-layer operations in registers
 // mtrunc: Number of elements that are non-zero at the front of data
-func fwht(data *[order]ffe, m, mtrunc int) {
+func fwht(data *[order]ffe, mtrunc int) {
 	// Decimation in time: Unroll 2 layers at a time
 	dist := 1
 	dist4 := 4
-	for dist4 <= m {
+	for dist4 <= order {
 		// For each set of dist*4 elements:
 		for r := 0; r < mtrunc; r += dist4 {
 			// For each set of dist elements:
@@ -900,7 +900,7 @@ func fwht(data *[order]ffe, m, mtrunc int) {
 	}
 
 	// If there is one layer left:
-	if dist < m {
+	if dist < order {
 		dist := uint16(dist)
 		for i := uint16(0); i < dist; i++ {
 			fwht2(&data[i], &data[i+dist])
@@ -1036,7 +1036,7 @@ func initFFTSkew() {
 	}
 	logWalsh[0] = 0
 
-	fwht(logWalsh, order, order)
+	fwht(logWalsh, order)
 }
 
 func initMul16LUT() {

--- a/leopard.go
+++ b/leopard.go
@@ -898,14 +898,6 @@ func fwht(data *[order]ffe, mtrunc int) {
 		dist = dist4
 		dist4 <<= 2
 	}
-
-	// If there is one layer left:
-	if dist < order {
-		dist := uint16(dist)
-		for i := uint16(0); i < dist; i++ {
-			fwht2(&data[i], &data[i+dist])
-		}
-	}
 }
 
 func fwht4(data []ffe, s int) {

--- a/leopard8.go
+++ b/leopard8.go
@@ -509,13 +509,13 @@ func (r *leopardFF8) reconstruct(shards [][]byte, recoverAll bool) error {
 		}
 
 		// Evaluate error locator polynomial8
-		fwht8(&errLocs, order8, m+r.dataShards)
+		fwht8(&errLocs, m+r.dataShards)
 
 		for i := 0; i < order8; i++ {
 			errLocs[i] = ffe8((uint(errLocs[i]) * uint(logWalsh8[i])) % modulus8)
 		}
 
-		fwht8(&errLocs, order8, order8)
+		fwht8(&errLocs, order8)
 
 		if r.inversion != nil {
 			c := leopardGF8cache{
@@ -943,11 +943,11 @@ func subMod8(a, b ffe8) ffe8 {
 // Decimation in time (DIT) Fast Walsh-Hadamard Transform
 // Unrolls pairs of layers to perform cross-layer operations in registers
 // mtrunc: Number of elements that are non-zero at the front of data
-func fwht8(data *[order8]ffe8, m, mtrunc int) {
+func fwht8(data *[order8]ffe8, mtrunc int) {
 	// Decimation in time: Unroll 2 layers at a time
 	dist := 1
 	dist4 := 4
-	for dist4 <= m {
+	for dist4 <= order8 {
 		// For each set of dist*4 elements:
 		for r := 0; r < mtrunc; r += dist4 {
 			// For each set of dist elements:
@@ -980,7 +980,7 @@ func fwht8(data *[order8]ffe8, m, mtrunc int) {
 	}
 
 	// If there is one layer left:
-	if dist < m {
+	if dist < order8 {
 		dist := uint16(dist)
 		for i := uint16(0); i < dist; i++ {
 			fwht28(&data[i], &data[i+dist])
@@ -1113,7 +1113,7 @@ func initFFTSkew8() {
 	}
 	logWalsh8[0] = 0
 
-	fwht8(logWalsh8, order8, order8)
+	fwht8(logWalsh8, order8)
 }
 
 func initMul8LUT() {

--- a/leopard8.go
+++ b/leopard8.go
@@ -978,14 +978,6 @@ func fwht8(data *[order8]ffe8, mtrunc int) {
 		dist = dist4
 		dist4 <<= 2
 	}
-
-	// If there is one layer left:
-	if dist < order8 {
-		dist := uint16(dist)
-		for i := uint16(0); i < dist; i++ {
-			fwht28(&data[i], &data[i+dist])
-		}
-	}
 }
 
 func fwht48(data []ffe8, s int) {


### PR DESCRIPTION
When reworking my [Rust implementation of leopard16](https://github.com/AndersTrier/reed-solomon-simd), I realized that the last loop in `fwht` is unreachable.

On the last iteration of the outermost loop, `dist4 == order`, after which we update the value of `dist` to `dist4`, making us unable to enter the body of the last loop.

`order` is always either 256 or 16384, and
```
In [2]: 4<<2<<2<<2
Out[2]: 256
```

```
In [5]: 4<<2<<2<<2<<2<<2<<2
Out[5]: 16384
```

On a related note: [I tried to optimize `fwht` further by using 8 values at a time (`fwht_8`)](https://github.com/AndersTrier/reed-solomon-simd/commit/cc200798ce53fe914fe5f1da92185ec919fce822). It was slightly faster on x86, but slower on ARM.
[`fwht_16`](https://github.com/AndersTrier/reed-solomon-simd/commit/3912577d1878bc4d27d7a39de3bbf63821009c6c) was slower on both architectures.