### PR TITLE
Fix build for Graviton4 processor

### DIFF
--- a/galois_arm64.go
+++ b/galois_arm64.go
@@ -13,7 +13,6 @@ func galMulNEON(low, high, in, out []byte)
 //go:noescape
 func galMulXorNEON(low, high, in, out []byte)
 
-//go:noescape
 func getVectorLength() (vl, pl uint64)
 
 func init() {

--- a/galois_arm64.go
+++ b/galois_arm64.go
@@ -13,6 +13,17 @@ func galMulNEON(low, high, in, out []byte)
 //go:noescape
 func galMulXorNEON(low, high, in, out []byte)
 
+//go:noescape
+func getVectorLength() (vl, pl uint64)
+
+func init() {
+	if defaultOptions.useSVE {
+		if vl, _ := getVectorLength(); vl != 256 {
+			defaultOptions.useSVE = false // Temp fix: disable SVE for non-256 vector widths (ie Graviton4)
+		}
+	}
+}
+
 func galMulSlice(c byte, in, out []byte, o *options) {
 	if c == 1 {
 		copy(out, in)

--- a/galois_arm64.s
+++ b/galois_arm64.s
@@ -6,6 +6,8 @@
 // Copyright 2015, Klaus Post, see LICENSE for details.
 // Copyright 2017, Minio, Inc.
 
+#include "textflag.h"
+
 #define LOAD(LO1, LO2, HI1, HI2) \
 	VLD1.P 32(R1), [LO1.B16, LO2.B16] \
 	                                  \
@@ -100,3 +102,14 @@ loopXor:
 
 completeXor:
 	RET
+
+TEXT ·getVectorLength(SB), NOSPLIT, $0
+    WORD $0xd2800002 // mov   x2, #0
+    WORD $0x04225022 // addvl x2, x2, #1
+    WORD $0xd37df042 // lsl   x2, x2, #3
+    WORD $0xd2800003 // mov   x3, #0
+    WORD $0x04635023 // addpl x3, x3, #1
+    WORD $0xd37df063 // lsl   x3, x3, #3
+    MOVD R2, vl+0(FP)
+    MOVD R3, pl+8(FP)
+    RET

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require github.com/klauspost/cpuid/v2 v2.2.6
 require golang.org/x/sys v0.5.0 // indirect
 
 retract (
+	v1.12.2 // https://github.com/klauspost/reedsolomon/pull/283
 	v1.11.6 // https://github.com/klauspost/reedsolomon/issues/240
 	[v1.11.3, v1.11.5] // https://github.com/klauspost/reedsolomon/pull/238
 	v1.11.2 // https://github.com/klauspost/reedsolomon/pull/229


### PR DESCRIPTION
This is a temp fix for the Graviton4 processor.

(Full fix will be vector-width agnostic as well as take advantage of some further improvements due to support for `SVE2` on Graviton4) 