### PR TITLE
Improve pure Go speed in low shard count

### DIFF
--- a/benchmark/main.go
+++ b/benchmark/main.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"math"
 	"math/rand"
@@ -143,8 +144,14 @@ func main() {
 
 	// Reduce GC overhead
 	debug.SetGCPercent(25)
+	rng := rand.New(rand.NewSource(0))
 	for i := range data {
 		data[i] = reedsolomon.AllocAligned(total, each)
+		for j := range data[i] {
+			// We fill with random data, otherwise lookups may not use the full tables
+			_, err := io.ReadFull(rng, data[i][j])
+			exitErr(err)
+		}
 	}
 	if *concurrent {
 		benchmarkEncodingConcurrent(enc, data)

--- a/benchmark/main.go
+++ b/benchmark/main.go
@@ -6,11 +6,14 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"log"
 	"math"
 	"math/rand"
 	"os"
 	"runtime"
 	"runtime/debug"
+	"runtime/pprof"
+	"runtime/trace"
 	"sort"
 	"strconv"
 	"strings"
@@ -37,6 +40,7 @@ var (
 	concurrent = flag.Bool("concurrent", false, "Run blocks in parallel")
 	cpu        = flag.Int("cpu", 16, "Set maximum number of cores to use")
 	csv        = flag.Bool("csv", false, "Output as CSV")
+	fast1      = flag.Bool("fast1", false, "Use fast 1 parity encoder (if available)")
 
 	sSE2     = flag.Bool("sse2", cpuid.CPU.Has(cpuid.SSE2), "Use SSE2")
 	sSSE3    = flag.Bool("ssse3", cpuid.CPU.Has(cpuid.SSSE3), "Use SSSE3")
@@ -44,6 +48,8 @@ var (
 	aVX512   = flag.Bool("avx512", cpuid.CPU.Supports(cpuid.AVX512F, cpuid.AVX512BW, cpuid.AVX512VL), "Use AVX512")
 	gNFI     = flag.Bool("gfni", cpuid.CPU.Supports(cpuid.AVX512F, cpuid.GFNI, cpuid.AVX512DQ), "Use AVX512+GFNI")
 	avx2GNFI = flag.Bool("avx-gfni", cpuid.CPU.Supports(cpuid.AVX2, cpuid.GFNI), "Use AVX+GFNI")
+
+	cpuprofile, memprofile, traceprofile string
 )
 
 var codecDefinitions = map[string]struct {
@@ -63,6 +69,9 @@ var codecDefinitions = map[string]struct {
 }
 
 func main() {
+	flag.StringVar(&cpuprofile, "cpu.profile", "", "write cpu profile to file")
+	flag.StringVar(&memprofile, "mem.profile", "", "write mem profile to file")
+	flag.StringVar(&traceprofile, "trace.profile", "", "write trace profile to file")
 	flag.Parse()
 	if *codecs {
 		printCodecs(0)
@@ -101,6 +110,35 @@ func main() {
 		*progress = false
 	} else {
 		fmt.Printf("Benchmarking %d block(s) of %d data (K) and %d parity shards (M), each %d bytes using %d threads. Total %d bytes.\n\n", *blocks, *kShards, *mShards, each, *cpu, *blocks*each*total)
+	}
+
+	if cpuprofile != "" {
+		f, err := os.Create(cpuprofile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		pprof.StartCPUProfile(f)
+		defer pprof.StopCPUProfile()
+	}
+	if memprofile != "" {
+		f, err := os.Create(memprofile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer f.Close()
+		defer pprof.WriteHeapProfile(f)
+	}
+	if traceprofile != "" {
+		f, err := os.Create(traceprofile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer f.Close()
+		err = trace.Start(f)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer trace.Stop()
 	}
 
 	// Reduce GC overhead
@@ -415,6 +453,9 @@ func getOptions(shardSize int) []reedsolomon.Option {
 	}
 	if !*invCache {
 		o = append(o, reedsolomon.WithInversionCache(false))
+	}
+	if *fast1 {
+		o = append(o, reedsolomon.WithFastOneParityMatrix())
 	}
 	o = append(o, reedsolomon.WithAutoGoroutines(shardSize))
 	return o

--- a/galois_amd64.go
+++ b/galois_amd64.go
@@ -81,6 +81,17 @@ func galMulSlice(c byte, in, out []byte, o *options) {
 		galMulSSSE3(mulTableLow[c][:], mulTableHigh[c][:], in, out)
 		in = in[done:]
 		out = out[done:]
+	} else if !o.skip2B {
+		mt16 := getMulTable16(c)
+		for len(in) >= 8 {
+			store16(out, mt16[load16(in, 0)], 0)
+			store16(out, mt16[load16(in, 2)], 2)
+			store16(out, mt16[load16(in, 4)], 4)
+			store16(out, mt16[load16(in, 6)], 6)
+
+			in = in[8:]
+			out = out[8:]
+		}
 	}
 	out = out[:len(in)]
 	mt := mulTable[c][:256]
@@ -125,6 +136,17 @@ func galMulSliceXor(c byte, in, out []byte, o *options) {
 		galMulSSSE3Xor(mulTableLow[c][:], mulTableHigh[c][:], in, out)
 		in = in[done:]
 		out = out[done:]
+	} else if !o.skip2B {
+		mt16 := getMulTable16(c)
+		for len(in) >= 8 {
+			store16(out, load16(out, 0)^mt16[load16(in, 0)], 0)
+			store16(out, load16(out, 2)^mt16[load16(in, 2)], 2)
+			store16(out, load16(out, 4)^mt16[load16(in, 4)], 4)
+			store16(out, load16(out, 6)^mt16[load16(in, 6)], 6)
+
+			in = in[8:]
+			out = out[8:]
+		}
 	}
 	if len(in) == 0 {
 		return

--- a/galois_noasm.go
+++ b/galois_noasm.go
@@ -12,9 +12,22 @@ func galMulSlice(c byte, in, out []byte, o *options) {
 		copy(out, in)
 		return
 	}
+	if !o.skip2B {
+		mt16 := getMulTable16(c)
+		for len(in) >= 8 {
+			store16(out, mt16[load16(in, 0)], 0)
+			store16(out, mt16[load16(in, 2)], 2)
+			store16(out, mt16[load16(in, 4)], 4)
+			store16(out, mt16[load16(in, 6)], 6)
+
+			in = in[8:]
+			out = out[8:]
+		}
+	}
+
 	mt := mulTable[c][:256]
 	for n, input := range in {
-		out[n] = mt[input]
+		store8(out, mt[input], n)
 	}
 }
 
@@ -24,9 +37,21 @@ func galMulSliceXor(c byte, in, out []byte, o *options) {
 		sliceXor(in, out, o)
 		return
 	}
+	if !o.skip2B {
+		mt16 := getMulTable16(c)
+		for len(in) >= 8 {
+			store16(out, load16(out, 0)^mt16[load16(in, 0)], 0)
+			store16(out, load16(out, 2)^mt16[load16(in, 2)], 2)
+			store16(out, load16(out, 4)^mt16[load16(in, 4)], 4)
+			store16(out, load16(out, 6)^mt16[load16(in, 6)], 6)
+
+			in = in[8:]
+			out = out[8:]
+		}
+	}
 	mt := mulTable[c][:256]
-	for n, input := range in {
-		out[n] ^= mt[input]
+	for n := range in {
+		store8(out, load8(out, n)^mt[load8(in, n)], n)
 	}
 }
 

--- a/galois_nopshufb_amd64.go
+++ b/galois_nopshufb_amd64.go
@@ -48,15 +48,17 @@ func galMulSlice(c byte, in, out []byte, o *options) {
 		return
 	}
 	mt := mulTable[c][:256]
-	mt16 := getMulTable16(c)
-	for len(in) >= 8 {
-		store16(out, mt16[load16(in, 0)], 0)
-		store16(out, mt16[load16(in, 2)], 2)
-		store16(out, mt16[load16(in, 4)], 4)
-		store16(out, mt16[load16(in, 6)], 6)
+	if !o.skip2B {
+		mt16 := getMulTable16(c)
+		for len(in) >= 8 {
+			store16(out, mt16[load16(in, 0)], 0)
+			store16(out, mt16[load16(in, 2)], 2)
+			store16(out, mt16[load16(in, 4)], 4)
+			store16(out, mt16[load16(in, 6)], 6)
 
-		in = in[8:]
-		out = out[8:]
+			in = in[8:]
+			out = out[8:]
+		}
 	}
 
 	for n, input := range in {
@@ -71,15 +73,17 @@ func galMulSliceXor(c byte, in, out []byte, o *options) {
 		return
 	}
 	mt := mulTable[c][:256]
-	mt16 := getMulTable16(c)
-	for len(in) >= 8 {
-		store16(out, load16(out, 0)^mt16[load16(in, 0)], 0)
-		store16(out, load16(out, 2)^mt16[load16(in, 2)], 2)
-		store16(out, load16(out, 4)^mt16[load16(in, 4)], 4)
-		store16(out, load16(out, 6)^mt16[load16(in, 6)], 6)
+	if !o.skip2B {
+		mt16 := getMulTable16(c)
+		for len(in) >= 8 {
+			store16(out, load16(out, 0)^mt16[load16(in, 0)], 0)
+			store16(out, load16(out, 2)^mt16[load16(in, 2)], 2)
+			store16(out, load16(out, 4)^mt16[load16(in, 4)], 4)
+			store16(out, load16(out, 6)^mt16[load16(in, 6)], 6)
 
-		in = in[8:]
-		out = out[8:]
+			in = in[8:]
+			out = out[8:]
+		}
 	}
 	for n, input := range in {
 		out[n] ^= mt[input]

--- a/galois_nopshufb_amd64.go
+++ b/galois_nopshufb_amd64.go
@@ -48,16 +48,17 @@ func galMulSlice(c byte, in, out []byte, o *options) {
 		return
 	}
 	mt := mulTable[c][:256]
-	for len(in) >= 4 {
-		ii := (*[4]byte)(in)
-		oo := (*[4]byte)(out)
-		oo[0] = mt[ii[0]]
-		oo[1] = mt[ii[1]]
-		oo[2] = mt[ii[2]]
-		oo[3] = mt[ii[3]]
-		in = in[4:]
-		out = out[4:]
+	mt16 := getMulTable16(c)
+	for len(in) >= 8 {
+		store16(out, mt16[load16(in, 0)], 0)
+		store16(out, mt16[load16(in, 2)], 2)
+		store16(out, mt16[load16(in, 4)], 4)
+		store16(out, mt16[load16(in, 6)], 6)
+
+		in = in[8:]
+		out = out[8:]
 	}
+
 	for n, input := range in {
 		out[n] = mt[input]
 	}
@@ -70,15 +71,15 @@ func galMulSliceXor(c byte, in, out []byte, o *options) {
 		return
 	}
 	mt := mulTable[c][:256]
-	for len(in) >= 4 {
-		ii := (*[4]byte)(in)
-		oo := (*[4]byte)(out)
-		oo[0] ^= mt[ii[0]]
-		oo[1] ^= mt[ii[1]]
-		oo[2] ^= mt[ii[2]]
-		oo[3] ^= mt[ii[3]]
-		in = in[4:]
-		out = out[4:]
+	mt16 := getMulTable16(c)
+	for len(in) >= 8 {
+		store16(out, load16(out, 0)^mt16[load16(in, 0)], 0)
+		store16(out, load16(out, 2)^mt16[load16(in, 2)], 2)
+		store16(out, load16(out, 4)^mt16[load16(in, 4)], 4)
+		store16(out, load16(out, 6)^mt16[load16(in, 6)], 6)
+
+		in = in[8:]
+		out = out[8:]
 	}
 	for n, input := range in {
 		out[n] ^= mt[input]

--- a/options.go
+++ b/options.go
@@ -25,6 +25,7 @@ type options struct {
 	useNEON,
 	useSVE bool
 	vectorLength int
+	skip2B       bool
 
 	useJerasureMatrix    bool
 	usePAR1Matrix        bool

--- a/reedsolomon.go
+++ b/reedsolomon.go
@@ -553,6 +553,10 @@ func New(dataShards, parityShards int, opts ...Option) (Encoder, error) {
 		r.o.maxGoroutines = gfniCodeGenMaxGoroutines
 	}
 
+	// Skip 2 byte table method if we have many shards.
+	// This is the approximate switchover for Zen5.
+	r.o.skip2B = dataShards+parityShards >= 20
+
 	// Inverted matrices are cached in a tree keyed by the indices
 	// of the invalid rows of the data to reconstruct.
 	// The inversion root node will have the identity matrix as
@@ -1688,4 +1692,8 @@ func (r *reedSolomon) Join(dst io.Writer, shards [][]byte, outSize int) error {
 		write -= n
 	}
 	return nil
+}
+
+type indexer interface {
+	int | int8 | int16 | int32 | int64 | uint | uint8 | uint16 | uint32 | uint64
 }

--- a/unsafe.go
+++ b/unsafe.go
@@ -1,4 +1,4 @@
-//go:build !noasm && !nounsafe && !gccgo && !appengine
+//go:build !nounsafe && !gccgo && !appengine
 
 /**
  * Reed-Solomon Coding over 8-bit values.
@@ -11,6 +11,8 @@ package reedsolomon
 import (
 	"unsafe"
 )
+
+const unsafeEnabled = true
 
 // AllocAligned allocates 'shards' slices, with 'each' bytes.
 // Each slice will start on a 64 byte aligned boundary.
@@ -38,4 +40,38 @@ func AllocAligned(shards, each int) [][]byte {
 		total = total[eachAligned:]
 	}
 	return res
+}
+
+// load64 will load from b at index i.
+func load64[I indexer](b []byte, i I) uint64 {
+	//return binary.LittleEndian.Uint64(b[i:])
+	//return *(*uint64)(unsafe.Pointer(&b[i]))
+	return *(*uint64)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), i))
+}
+
+// Store64 will store v at b.
+func store64[I indexer](b []byte, v uint64, i I) {
+	//binary.LittleEndian.PutUint64(b[i:], v)
+	*(*uint64)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), i)) = v
+}
+
+// load16 will load from b at index i.
+func load16[I indexer](b []byte, i I) uint16 {
+	//return binary.LittleEndian.Uint64(b[i:])
+	//return *(*uint64)(unsafe.Pointer(&b[i]))
+	return *(*uint16)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), i))
+}
+
+// Store16 will store v at b.
+func store16[I indexer](b []byte, v uint16, i I) {
+	//binary.LittleEndian.PutUint64(b[i:], v)
+	*(*uint16)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), i)) = v
+}
+
+func load8[I indexer](b []byte, i I) uint8 {
+	return *(*uint8)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), i))
+}
+
+func store8[I indexer](b []byte, v uint8, i I) {
+	*(*uint8)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), i)) = v
 }

--- a/unsafe.go
+++ b/unsafe.go
@@ -45,33 +45,32 @@ func AllocAligned(shards, each int) [][]byte {
 // load64 will load from b at index i.
 func load64[I indexer](b []byte, i I) uint64 {
 	//return binary.LittleEndian.Uint64(b[i:])
-	//return *(*uint64)(unsafe.Pointer(&b[i]))
-	return *(*uint64)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), i))
+	return *(*uint64)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), unsafe.IntegerType(i)))
 }
 
 // Store64 will store v at b.
 func store64[I indexer](b []byte, v uint64, i I) {
 	//binary.LittleEndian.PutUint64(b[i:], v)
-	*(*uint64)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), i)) = v
+	*(*uint64)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), unsafe.IntegerType(i))) = v
 }
 
 // load16 will load from b at index i.
 func load16[I indexer](b []byte, i I) uint16 {
 	//return binary.LittleEndian.Uint64(b[i:])
 	//return *(*uint64)(unsafe.Pointer(&b[i]))
-	return *(*uint16)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), i))
+	return *(*uint16)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), unsafe.IntegerType(i)))
 }
 
 // Store16 will store v at b.
 func store16[I indexer](b []byte, v uint16, i I) {
 	//binary.LittleEndian.PutUint64(b[i:], v)
-	*(*uint16)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), i)) = v
+	*(*uint16)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), unsafe.IntegerType(i))) = v
 }
 
 func load8[I indexer](b []byte, i I) uint8 {
-	return *(*uint8)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), i))
+	return *(*uint8)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), unsafe.IntegerType(i)))
 }
 
 func store8[I indexer](b []byte, v uint8, i I) {
-	*(*uint8)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), i)) = v
+	*(*uint8)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), unsafe.IntegerType(i))) = v
 }

--- a/unsafe.go
+++ b/unsafe.go
@@ -45,32 +45,33 @@ func AllocAligned(shards, each int) [][]byte {
 // load64 will load from b at index i.
 func load64[I indexer](b []byte, i I) uint64 {
 	//return binary.LittleEndian.Uint64(b[i:])
-	return *(*uint64)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), unsafe.IntegerType(i)))
+	//return *(*uint64)(unsafe.Pointer(&b[i]))
+	return *(*uint64)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), i))
 }
 
 // Store64 will store v at b.
 func store64[I indexer](b []byte, v uint64, i I) {
 	//binary.LittleEndian.PutUint64(b[i:], v)
-	*(*uint64)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), unsafe.IntegerType(i))) = v
+	*(*uint64)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), i)) = v
 }
 
 // load16 will load from b at index i.
 func load16[I indexer](b []byte, i I) uint16 {
 	//return binary.LittleEndian.Uint64(b[i:])
 	//return *(*uint64)(unsafe.Pointer(&b[i]))
-	return *(*uint16)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), unsafe.IntegerType(i)))
+	return *(*uint16)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), i))
 }
 
 // Store16 will store v at b.
 func store16[I indexer](b []byte, v uint16, i I) {
 	//binary.LittleEndian.PutUint64(b[i:], v)
-	*(*uint16)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), unsafe.IntegerType(i))) = v
+	*(*uint16)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), i)) = v
 }
 
 func load8[I indexer](b []byte, i I) uint8 {
-	return *(*uint8)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), unsafe.IntegerType(i)))
+	return *(*uint8)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), i))
 }
 
 func store8[I indexer](b []byte, v uint8, i I) {
-	*(*uint8)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), unsafe.IntegerType(i))) = v
+	*(*uint8)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), i)) = v
 }

--- a/unsafe_disabled.go
+++ b/unsafe_disabled.go
@@ -1,4 +1,4 @@
-//go:build noasm || nounsafe || gccgo || appengine
+//go:build nounsafe || gccgo || appengine
 
 /**
  * Reed-Solomon Coding over 8-bit values.
@@ -7,6 +7,10 @@
  */
 
 package reedsolomon
+
+import "encoding/binary"
+
+const unsafeEnabled = false
 
 // AllocAligned allocates 'shards' slices, with 'each' bytes.
 // Each slice will start on a 64 byte aligned boundary.
@@ -20,4 +24,32 @@ func AllocAligned(shards, each int) [][]byte {
 		total = total[eachAligned:]
 	}
 	return res
+}
+
+// load64 will load from b at index i.
+func load64[I indexer](b []byte, i I) uint64 {
+	return binary.LittleEndian.Uint64(b[i:])
+}
+
+// Store64 will store v at b.
+func store64[I indexer](b []byte, v uint64, i I) {
+	binary.LittleEndian.PutUint64(b[i:], v)
+}
+
+// load8 will load from b at index i.
+func load8[I indexer](b []byte, i I) byte {
+	return b[i]
+}
+
+// load16 will load from b at index i.
+func load16[I indexer](b []byte, i I) uint16 {
+	return binary.LittleEndian.Uint16(b[i:])
+}
+
+func store16[I indexer](b []byte, v uint16, i I) {
+	binary.LittleEndian.PutUint16(b[i:], v)
+}
+
+func store8[I indexer](b []byte, v byte, i I) {
+	b[i] = v
 }


### PR DESCRIPTION
Add a 32MB lookup table that allows looking up 2 values at once. Will only be used when no assembly functions are available.

Benchmarks: (with no assembly)

```
benchmark                                                old ns/op      new ns/op      delta
BenchmarkGalois128K-32                                   24802          15883          -35.96%
BenchmarkGalois1M-32                                     202043         123711         -38.77%
BenchmarkGaloisXor128K-32                                29152          18226          -37.48%
BenchmarkGaloisXor1M-32                                  230820         148170         -35.81%
BenchmarkEncode2x1x1M-32                                 25016          25261          +0.98%
BenchmarkEncode800x200/64-32                             127666         103062         -19.27%
BenchmarkEncode800x200/256-32                            470906         354406         -24.74%
BenchmarkEncode800x200/1024-32                           1835598        1377017        -24.98%
BenchmarkEncode800x200/4096-32                           7423581        5238705        -29.43%
BenchmarkEncode800x200/16384-32                          30795690       21454123       -30.33%
BenchmarkEncode800x200/65536-32                          120715900      96913158       -19.72%
BenchmarkEncode800x200/262144-32                         490054033      368235100      -24.86%
BenchmarkEncode800x200/1048576-32                        2011852300     1549867400     -22.96%
BenchmarkEncode1K/4+4/cauchy-32                          4894           2764           -43.52%
BenchmarkEncode1K/8+8/cauchy-32                          17621          11426          -35.16%
BenchmarkEncode1K/16+16/cauchy-32                        66220          58349          -11.89%
BenchmarkEncode1K/32+32/cauchy-32                        257469         239701         -6.90%
BenchmarkEncode1K/64+64/cauchy-32                        1041104        967883         -7.03%
BenchmarkEncode1K/128+128/cauchy-32                      4065196        4178904        +2.80%
BenchmarkDecode1K/4+4/cauchy-32                          5928           3833           -35.34%
BenchmarkDecode1K/4+4/cauchy-inv-32                      5853           3487           -40.42%
BenchmarkDecode1K/4+4/cauchy-single-32                   1790           1193           -33.35%
BenchmarkDecode1K/4+4/cauchy-single-inv-32               1448           904            -37.58%
BenchmarkDecode1K/8+8/cauchy-32                          20207          13253          -34.41%
BenchmarkDecode1K/8+8/cauchy-inv-32                      19062          11996          -37.07%
BenchmarkDecode1K/8+8/cauchy-single-32                   3579           2252           -37.08%
BenchmarkDecode1K/8+8/cauchy-single-inv-32               2609           1605           -38.48%
BenchmarkDecode1K/16+16/cauchy-32                        119255         70093          -41.22%
BenchmarkDecode1K/16+16/cauchy-inv-32                    92758          59753          -35.58%
BenchmarkDecode1K/16+16/cauchy-single-32                 7827           5863           -25.09%
BenchmarkDecode1K/16+16/cauchy-single-inv-32             6115           3981           -34.90%
BenchmarkDecode1K/32+32/cauchy-32                        320032         294357         -8.02%
BenchmarkDecode1K/32+32/cauchy-inv-32                    277815         239258         -13.88%
BenchmarkDecode1K/32+32/cauchy-single-32                 15596          13458          -13.71%
BenchmarkDecode1K/32+32/cauchy-single-inv-32             9237           7938           -14.06%
BenchmarkDecode1K/64+64/cauchy-32                        1401801        1369309        -2.32%
BenchmarkDecode1K/64+64/cauchy-inv-32                    1067298        955657         -10.46%
BenchmarkDecode1K/64+64/cauchy-single-32                 41705          35822          -14.11%
BenchmarkDecode1K/64+64/cauchy-single-inv-32             19323          15517          -19.70%
BenchmarkDecode1K/128+128/cauchy-32                      7225691        7160856        -0.90%
BenchmarkDecode1K/128+128/cauchy-inv-32                  4159486        3818808        -8.19%
BenchmarkDecode1K/128+128/cauchy-single-32               124440         109424         -12.07%
BenchmarkDecode1K/128+128/cauchy-single-inv-32           36524          31136          -14.75%
BenchmarkEncode10x2x10000-32                             50440          42083          -16.57%
BenchmarkEncode100x20x10000-32                           1801528        1106006        -38.61%
BenchmarkEncode17x3x1M-32                                1288167        1001932        -22.22%
BenchmarkEncode10x4x16M-32                               13472620       10327386       -23.35%
BenchmarkEncode5x2x1M-32                                 310911         185120         -40.46%
BenchmarkEncode10x2x1M-32                                589206         410960         -30.25%
BenchmarkEncode10x4x1M-32                                1015838        866408         -14.71%
BenchmarkEncode50x20x1M-32                               22557354       19183256       -14.96%
BenchmarkEncode17x3x16M-32                               16104608       13499597       -16.18%
BenchmarkEncode_8x4x8M-32                                5519244        3932924        -28.74%
BenchmarkEncode_12x4x12M-32                              12346553       9079752        -26.46%
BenchmarkEncode_16x4x16M-32                              21485559       17850644       -16.92%
BenchmarkEncode_16x4x32M-32                              42595970       35871009       -15.79%
BenchmarkEncode_16x4x64M-32                              82783715       69571462       -15.96%
BenchmarkEncode_8x5x8M-32                                7074967        5185001        -26.71%
BenchmarkEncode_8x6x8M-32                                8509701        6225369        -26.84%
BenchmarkEncode_8x7x8M-32                                9515548        7190973        -24.43%
BenchmarkEncode_8x9x8M-32                                12594933       10125813       -19.60%
BenchmarkEncode_8x10x8M-32                               13865411       11618479       -16.21%
BenchmarkEncode_8x11x8M-32                               14907551       13268491       -10.99%
BenchmarkEncode_8x8x05M-32                               969947         684114         -29.47%
BenchmarkEncode_8x8x1M-32                                1626195        1284539        -21.01%
BenchmarkEncode_8x8x8M-32                                11010901       8424452        -23.49%
BenchmarkEncode_8x8x32M-32                               42695493       32035889       -24.97%
BenchmarkEncode_24x8x24M-32                              96542217       79041486       -18.13%
BenchmarkEncode_24x8x48M-32                              188859267      155747871      -17.53%
BenchmarkVerify800x200/64-32                             135567         109423         -19.28%
BenchmarkVerify800x200/256-32                            481634         347095         -27.93%
BenchmarkVerify800x200/1024-32                           1869884        1322751        -29.26%
BenchmarkVerify800x200/4096-32                           7491368        5123890        -31.60%
BenchmarkVerify800x200/16384-32                          29535987       20752858       -29.74%
BenchmarkVerify800x200/65536-32                          125985833      85297623       -32.30%
BenchmarkVerify800x200/262144-32                         508379267      355721767      -30.03%
BenchmarkVerify800x200/1048576-32                        2068388300     1449036800     -29.94%
BenchmarkVerify10x2x10000-32                             53561          42944          -19.82%
BenchmarkVerify50x5x100000-32                            907225         783960         -13.59%
BenchmarkVerify10x2x1M-32                                640749         536002         -16.35%
BenchmarkVerify5x2x1M-32                                 396362         304214         -23.25%
BenchmarkVerify10x4x1M-32                                1212746        1091746        -9.98%
BenchmarkVerify50x20x1M-32                               24401410       20788040       -14.81%
BenchmarkVerify10x4x16M-32                               17572573       14192901       -19.23%
BenchmarkReconstruct10x2x10000-32                        35819          40261          +12.40%
BenchmarkReconstruct800x200/64-32                        910172         847324         -6.91%
BenchmarkReconstruct800x200/256-32                       1950439        1606723        -17.62%
BenchmarkReconstruct800x200/1024-32                      5781554        4567305        -21.00%
BenchmarkReconstruct800x200/4096-32                      21559582       16228687       -24.73%
BenchmarkReconstruct800x200/16384-32                     84484767       61475983       -27.23%
BenchmarkReconstruct800x200/65536-32                     352869233      257830060      -26.93%
BenchmarkReconstruct800x200/262144-32                    1505845200     1137826500     -24.44%
BenchmarkReconstruct800x200/1048576-32                   6090028900     4613878500     -24.24%
BenchmarkReconstruct50x5x50000-32                        689686         465919         -32.44%
BenchmarkReconstruct10x2x1M-32                           514134         376113         -26.85%
BenchmarkReconstruct5x2x1M-32                            309217         163760         -47.04%
BenchmarkReconstruct10x4x1M-32                           751008         634086         -15.57%
BenchmarkReconstruct50x20x1M-32                          11040695       8815629        -20.15%
BenchmarkReconstruct10x4x16M-32                          8192061        7168362        -12.50%
BenchmarkReconstructData10x2x10000-32                    37946          38289          +0.90%
BenchmarkReconstructData800x200/64-32                    981698         846979         -13.72%
BenchmarkReconstructData800x200/256-32                   1962800        1593880        -18.80%
BenchmarkReconstructData800x200/1024-32                  5818608        4503410        -22.60%
BenchmarkReconstructData800x200/4096-32                  22954233       15814243       -31.11%
BenchmarkReconstructData800x200/16384-32                 88836892       63010456       -29.07%
BenchmarkReconstructData800x200/65536-32                 384783267      246166020      -36.02%
BenchmarkReconstructData800x200/262144-32                1265891200     1127835600     -10.91%
BenchmarkReconstructData800x200/1048576-32               5463190100     4630147200     -15.25%
BenchmarkReconstructData50x5x50000-32                    667775         465496         -30.29%
BenchmarkReconstructData10x2x1M-32                       513945         369514         -28.10%
BenchmarkReconstructData5x2x1M-32                        282178         151657         -46.25%
BenchmarkReconstructData10x4x1M-32                       724144         593335         -18.06%
BenchmarkReconstructData50x20x1M-32                      11100261       9621467        -13.32%
BenchmarkReconstructData10x4x16M-32                      8161166        6423180        -21.30%
BenchmarkReconstructP10x2x10000-32                       2975           2759           -7.26%
BenchmarkReconstructP10x5x20000-32                       10975          11836          +7.85%
BenchmarkSplit10x4x160M-32                               2171627        2003794        -7.73%
BenchmarkSplit5x2x5M-32                                  68340          62255          -8.90%
BenchmarkSplit10x2x1M-32                                 11724          10878          -7.22%
BenchmarkSplit10x4x10M-32                                127757         126308         -1.13%
BenchmarkSplit50x20x50M-32                               631860         606853         -3.96%
BenchmarkSplit17x3x272M-32                               1603306        1504980        -6.13%
BenchmarkParallel_8x8x64K-32                             81963          62322          -23.96%
BenchmarkParallel_8x8x05M-32                             657356         493039         -25.00%
BenchmarkParallel_20x10x05M-32                           2035771        1701756        -16.41%
BenchmarkParallel_8x8x1M-32                              1312086        989650         -24.57%
BenchmarkParallel_8x8x8M-32                              12395383       8855818        -28.56%
BenchmarkParallel_8x8x32M-32                             145119543      46900712       -67.68%
BenchmarkParallel_8x3x1M-32                              488483         346840         -29.00%
BenchmarkParallel_8x4x1M-32                              652976         466834         -28.51%
BenchmarkParallel_8x5x1M-32                              847350         599749         -29.22%
BenchmarkStreamEncode10x2x10000-32                       53168          44803          -15.73%
BenchmarkStreamEncode100x20x10000-32                     1967911        1206515        -38.69%
BenchmarkStreamEncode17x3x1M-32                          1825471        1604931        -12.08%
BenchmarkStreamEncode10x4x16M-32                         20421472       17869211       -12.50%
BenchmarkStreamEncode5x2x1M-32                           512446         434971         -15.12%
BenchmarkStreamEncode10x2x1M-32                          931308         847344         -9.02%
BenchmarkStreamEncode10x4x1M-32                          1385173        1276586        -7.84%
BenchmarkStreamEncode50x20x1M-32                         24626658       22235222       -9.71%
BenchmarkStreamEncode17x3x16M-32                         28870364       25197182       -12.72%
BenchmarkStreamVerify10x2x10000-32                       59623          46435          -22.12%
BenchmarkStreamVerify50x5x50000-32                       1349335        1316518        -2.43%
BenchmarkStreamVerify10x2x1M-32                          1037307        934257         -9.93%
BenchmarkStreamVerify5x2x1M-32                           649599         551300         -15.13%
BenchmarkStreamVerify10x4x1M-32                          1694152        1497405        -11.61%
BenchmarkStreamVerify50x20x1M-32                         26931902       23227298       -13.76%
BenchmarkStreamVerify10x4x16M-32                         25068808       20562626       -17.98%

benchmark                                                old MB/s      new MB/s      speedup
BenchmarkGalois128K-32                                   5284.82       8252.31       1.56x
BenchmarkGalois1M-32                                     5189.86       8475.99       1.63x
BenchmarkGaloisXor128K-32                                4496.17       7191.61       1.60x
BenchmarkGaloisXor1M-32                                  4542.83       7076.83       1.56x
BenchmarkEncode2x1x1M-32                                 125747.73     124529.14     0.99x
BenchmarkEncode800x200/64-32                             501.31        620.99        1.24x
BenchmarkEncode800x200/256-32                            543.63        722.34        1.33x
BenchmarkEncode800x200/1024-32                           557.86        743.64        1.33x
BenchmarkEncode800x200/4096-32                           551.76        781.87        1.42x
BenchmarkEncode800x200/16384-32                          532.02        763.68        1.44x
BenchmarkEncode800x200/65536-32                          542.89        676.23        1.25x
BenchmarkEncode800x200/262144-32                         534.93        711.89        1.33x
BenchmarkEncode800x200/1048576-32                        521.20        676.56        1.30x
BenchmarkEncode1K/4+4/cauchy-32                          1673.81       2963.98       1.77x
BenchmarkEncode1K/8+8/cauchy-32                          929.79        1433.96       1.54x
BenchmarkEncode1K/16+16/cauchy-32                        494.84        561.59        1.13x
BenchmarkEncode1K/32+32/cauchy-32                        254.54        273.41        1.07x
BenchmarkEncode1K/64+64/cauchy-32                        125.90        135.42        1.08x
BenchmarkEncode1K/128+128/cauchy-32                      64.48         62.73         0.97x
BenchmarkDecode1K/4+4/cauchy-32                          1381.93       2137.44       1.55x
BenchmarkDecode1K/4+4/cauchy-inv-32                      1399.72       2349.22       1.68x
BenchmarkDecode1K/4+4/cauchy-single-32                   4575.70       6869.25       1.50x
BenchmarkDecode1K/4+4/cauchy-single-inv-32               5657.40       9062.93       1.60x
BenchmarkDecode1K/8+8/cauchy-32                          810.82        1236.21       1.52x
BenchmarkDecode1K/8+8/cauchy-inv-32                      859.53        1365.73       1.59x
BenchmarkDecode1K/8+8/cauchy-single-32                   4577.48       7275.14       1.59x
BenchmarkDecode1K/8+8/cauchy-single-inv-32               6279.80       10205.55      1.63x
BenchmarkDecode1K/16+16/cauchy-32                        274.77        467.49        1.70x
BenchmarkDecode1K/16+16/cauchy-inv-32                    353.26        548.39        1.55x
BenchmarkDecode1K/16+16/cauchy-single-32                 4186.28       5588.65       1.33x
BenchmarkDecode1K/16+16/cauchy-single-inv-32             5358.52       8230.70       1.54x
BenchmarkDecode1K/32+32/cauchy-32                        204.78        222.64        1.09x
BenchmarkDecode1K/32+32/cauchy-inv-32                    235.90        273.91        1.16x
BenchmarkDecode1K/32+32/cauchy-single-32                 4202.16       4869.76       1.16x
BenchmarkDecode1K/32+32/cauchy-single-inv-32             7095.27       8255.89       1.16x
BenchmarkDecode1K/64+64/cauchy-32                        93.50         95.72         1.02x
BenchmarkDecode1K/64+64/cauchy-inv-32                    122.81        137.15        1.12x
BenchmarkDecode1K/64+64/cauchy-single-32                 3142.82       3658.95       1.16x
BenchmarkDecode1K/64+64/cauchy-single-inv-32             6783.14       8446.98       1.25x
BenchmarkDecode1K/128+128/cauchy-32                      36.28         36.61         1.01x
BenchmarkDecode1K/128+128/cauchy-inv-32                  63.02         68.65         1.09x
BenchmarkDecode1K/128+128/cauchy-single-32               2106.58       2395.66       1.14x
BenchmarkDecode1K/128+128/cauchy-single-inv-32           7177.38       8419.32       1.17x
BenchmarkEncode10x2x10000-32                             2379.08       2851.50       1.20x
BenchmarkEncode100x20x10000-32                           666.10        1084.98       1.63x
BenchmarkEncode17x3x1M-32                                16280.13      20931.08      1.29x
BenchmarkEncode10x4x16M-32                               17433.95      22743.51      1.30x
BenchmarkEncode5x2x1M-32                                 23608.18      39650.03      1.68x
BenchmarkEncode10x2x1M-32                                21355.70      30618.31      1.43x
BenchmarkEncode10x4x1M-32                                14451.19      16943.58      1.17x
BenchmarkEncode50x20x1M-32                               3253.94       3826.27       1.18x
BenchmarkEncode17x3x16M-32                               20835.30      24855.88      1.19x
BenchmarkEncode_8x4x8M-32                                18238.60      25595.03      1.40x
BenchmarkEncode_12x4x12M-32                              16306.30      22173.14      1.36x
BenchmarkEncode_16x4x16M-32                              15617.20      18797.32      1.20x
BenchmarkEncode_16x4x32M-32                              15754.74      18708.38      1.19x
BenchmarkEncode_16x4x64M-32                              16213.06      19292.07      1.19x
BenchmarkEncode_8x5x8M-32                                15413.77      21032.18      1.36x
BenchmarkEncode_8x6x8M-32                                13800.78      18864.83      1.37x
BenchmarkEncode_8x7x8M-32                                13223.53      17498.20      1.32x
BenchmarkEncode_8x9x8M-32                                11322.52      14083.45      1.24x
BenchmarkEncode_8x10x8M-32                               10890.04      12996.10      1.19x
BenchmarkEncode_8x11x8M-32                               10691.46      12012.18      1.12x
BenchmarkEncode_8x8x05M-32                               8648.52       12262.00      1.42x
BenchmarkEncode_8x8x1M-32                                10316.85      13060.88      1.27x
BenchmarkEncode_8x8x8M-32                                12189.53      15931.92      1.31x
BenchmarkEncode_8x8x32M-32                               12574.42      16758.42      1.33x
BenchmarkEncode_24x8x24M-32                              8341.49       10188.40      1.22x
BenchmarkEncode_24x8x48M-32                              8528.11       10341.15      1.21x
BenchmarkVerify800x200/64-32                             472.09        584.89        1.24x
BenchmarkVerify800x200/256-32                            531.52        737.55        1.39x
BenchmarkVerify800x200/1024-32                           547.63        774.14        1.41x
BenchmarkVerify800x200/4096-32                           546.76        799.39        1.46x
BenchmarkVerify800x200/16384-32                          554.71        789.48        1.42x
BenchmarkVerify800x200/65536-32                          520.19        768.32        1.48x
BenchmarkVerify800x200/262144-32                         515.65        736.94        1.43x
BenchmarkVerify800x200/1048576-32                        506.95        723.64        1.43x
BenchmarkVerify10x2x10000-32                             2240.42       2794.32       1.25x
BenchmarkVerify50x5x100000-32                            6062.44       7015.67       1.16x
BenchmarkVerify10x2x1M-32                                19637.81      23475.50      1.20x
BenchmarkVerify5x2x1M-32                                 18518.52      24127.82      1.30x
BenchmarkVerify10x4x1M-32                                12104.82      13446.41      1.11x
BenchmarkVerify50x20x1M-32                               3008.04       3530.89       1.17x
BenchmarkVerify10x4x16M-32                               13366.34      16549.19      1.24x
BenchmarkReconstruct10x2x10000-32                        3350.18       2980.57       0.89x
BenchmarkReconstruct800x200/64-32                        70.32         75.53         1.07x
BenchmarkReconstruct800x200/256-32                       131.25        159.33        1.21x
BenchmarkReconstruct800x200/1024-32                      177.12        224.20        1.27x
BenchmarkReconstruct800x200/4096-32                      189.99        252.39        1.33x
BenchmarkReconstruct800x200/16384-32                     193.93        266.51        1.37x
BenchmarkReconstruct800x200/65536-32                     185.72        254.18        1.37x
BenchmarkReconstruct800x200/262144-32                    174.08        230.39        1.32x
BenchmarkReconstruct800x200/1048576-32                   172.18        227.27        1.32x
BenchmarkReconstruct50x5x50000-32                        7974.64       11804.62      1.48x
BenchmarkReconstruct10x2x1M-32                           24473.99      33455.17      1.37x
BenchmarkReconstruct5x2x1M-32                            23737.47      44822.02      1.89x
BenchmarkReconstruct10x4x1M-32                           19547.15      23151.54      1.18x
BenchmarkReconstruct50x20x1M-32                          6648.16       8326.16       1.25x
BenchmarkReconstruct10x4x16M-32                          28671.79      32766.35      1.14x
BenchmarkReconstructData10x2x10000-32                    3162.37       3134.05       0.99x
BenchmarkReconstructData800x200/64-32                    65.19         75.56         1.16x
BenchmarkReconstructData800x200/256-32                   130.43        160.61        1.23x
BenchmarkReconstructData800x200/1024-32                  175.99        227.38        1.29x
BenchmarkReconstructData800x200/4096-32                  178.44        259.01        1.45x
BenchmarkReconstructData800x200/16384-32                 184.43        260.02        1.41x
BenchmarkReconstructData800x200/65536-32                 170.32        266.23        1.56x
BenchmarkReconstructData800x200/262144-32                207.08        232.43        1.12x
BenchmarkReconstructData800x200/1048576-32               191.93        226.47        1.18x
BenchmarkReconstructData50x5x50000-32                    8236.31       11815.36      1.43x
BenchmarkReconstructData10x2x1M-32                       24482.98      34052.56      1.39x
BenchmarkReconstructData5x2x1M-32                        26012.05      48398.94      1.86x
BenchmarkReconstructData10x4x1M-32                       20272.31      24741.62      1.22x
BenchmarkReconstructData50x20x1M-32                      6612.49       7628.81       1.15x
BenchmarkReconstructData10x4x16M-32                      28780.33      36567.72      1.27x
BenchmarkReconstructP10x2x10000-32                       40334.81      43493.13      1.08x
BenchmarkReconstructP10x5x20000-32                       27335.36      25347.36      0.93x
BenchmarkParallel_8x8x64K-32                             12793.36      16825.03      1.32x
BenchmarkParallel_8x8x05M-32                             12761.14      17014.08      1.33x
BenchmarkParallel_20x10x05M-32                           7726.13       9242.59       1.20x
BenchmarkParallel_8x8x1M-32                              12786.67      16952.67      1.33x
BenchmarkParallel_8x8x8M-32                              10828.04      15155.88      1.40x
BenchmarkParallel_8x8x32M-32                             3699.51       11446.97      3.09x
BenchmarkParallel_8x3x1M-32                              23612.54      33255.54      1.41x
BenchmarkParallel_8x4x1M-32                              19270.09      26953.70      1.40x
BenchmarkParallel_8x5x1M-32                              16087.19      22728.65      1.41x
BenchmarkStreamEncode10x2x10000-32                       1880.84       2231.98       1.19x
BenchmarkStreamEncode100x20x10000-32                     508.15        828.83        1.63x
BenchmarkStreamEncode17x3x1M-32                          9765.04       11106.89      1.14x
BenchmarkStreamEncode10x4x16M-32                         8215.48       9388.90       1.14x
BenchmarkStreamEncode5x2x1M-32                           10231.09      12053.39      1.18x
BenchmarkStreamEncode10x2x1M-32                          11259.17      12374.86      1.10x
BenchmarkStreamEncode10x4x1M-32                          7570.00       8213.91       1.09x
BenchmarkStreamEncode50x20x1M-32                         2128.95       2357.92       1.11x
BenchmarkStreamEncode17x3x16M-32                         9879.08       11319.23      1.15x
BenchmarkStreamVerify10x2x10000-32                       1677.21       2153.54       1.28x
BenchmarkStreamVerify50x5x50000-32                       3705.53       3797.90       1.02x
BenchmarkStreamVerify10x2x1M-32                          10108.64      11223.64      1.11x
BenchmarkStreamVerify5x2x1M-32                           8070.95       9510.04       1.18x
BenchmarkStreamVerify10x4x1M-32                          6189.39       7002.62       1.13x
BenchmarkStreamVerify50x20x1M-32                         1946.72       2257.21       1.16x
BenchmarkStreamVerify10x4x16M-32                         6692.47       8159.08       1.22x

```

Disabled when shard count gets high as speed degenerates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Benchmark tool: optional CPU, memory, and trace profiling via CLI flags that write profiles to specified paths.
  - CLI flag to enable an alternative fast single-parity encoding path.

- **Performance**
  - Improved non-SIMD/non-assembly fallbacks with wider chunk processing for higher throughput.
  - Runtime switch to choose a different encoding strategy for large shard counts.

- **Chores**
  - Build constraints and low-level memory access helpers updated to support new runtime paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->