### PR TITLE
padding length check

### DIFF
--- a/leopard.go
+++ b/leopard.go
@@ -12,6 +12,7 @@ package reedsolomon
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"math/bits"
 	"sync"
@@ -321,6 +322,9 @@ func (r *leopardFF16) Split(data []byte) ([][]byte, error) {
 		data = data[perShard:]
 	}
 
+	if len(padding) < len(dst)-i {
+		return nil, fmt.Errorf("insufficient padding: need %d shards, have %d", len(dst)-i, len(padding))
+	}
 	for j := 0; i+j < len(dst); j++ {
 		dst[i+j] = padding[0]
 		padding = padding[1:]

--- a/leopard8.go
+++ b/leopard8.go
@@ -13,6 +13,7 @@ package reedsolomon
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"math/bits"
 	"sync"
@@ -357,6 +358,9 @@ func (r *leopardFF8) Split(data []byte) ([][]byte, error) {
 		data = data[perShard:]
 	}
 
+	if len(padding) < len(dst)-i {
+		return nil, fmt.Errorf("insufficient padding: need %d shards, have %d", len(dst)-i, len(padding))
+	}
 	for j := 0; i+j < len(dst); j++ {
 		dst[i+j] = padding[0]
 		padding = padding[1:]

--- a/reedsolomon.go
+++ b/reedsolomon.go
@@ -1634,6 +1634,9 @@ func (r *reedSolomon) Split(data []byte) ([][]byte, error) {
 		data = data[perShard:]
 	}
 
+	if len(padding) < len(dst)-i {
+		return nil, fmt.Errorf("insufficient padding: need %d shards, have %d", len(dst)-i, len(padding))
+	}
 	for j := 0; i+j < len(dst); j++ {
 		dst[i+j] = padding[0]
 		padding = padding[1:]


### PR DESCRIPTION
preventing panic (out of range).
The Svace static analyzer (https://www.ispras.ru/en/technologies/svace/) flagged this code as suspicious: it could lead to a panic (out of range) because padding length might be insufficient

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to detect insufficient padding during data splitting, preventing edge-case crashes and out-of-bounds behavior.
  * Returns a clear, actionable error when inputs can’t be split due to missing padding, improving diagnosability and stability.
  * Ensures consistent behavior across implementations, especially with malformed or truncated inputs, without changing any public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->