### PR TITLE
Allow setting shard size on benchmark

### DIFF
--- a/benchmark/main.go
+++ b/benchmark/main.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	blockSize  = flag.String("size", "10MiB", "Size of each input block. Prefix with 'each:' to set block size.")
+	blockSize  = flag.String("size", "10MiB", "Size of each input block. Prefix with 'each:' to set shard size.")
 	blocks     = flag.Int("blocks", 1, "Total number of blocks")
 	kShards    = flag.Int("k", 12, "Data shards")
 	mShards    = flag.Int("m", 4, "Parity shards")


### PR DESCRIPTION
Example: `benchmark -k 16384 -m 16384 -size=each:1024 -codec leopard16`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Block size parameter now supports an "EACH:<n>" prefix to scale reported block size according to the number of data blocks, making size configuration more flexible for multi-block runs.

* **Documentation**
  * Updated help text to explain the new "each:" prefix and how it affects block size interpretation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->