### PR TITLE
Improve fwht2alt when inlined

### DIFF
--- a/leopard.go
+++ b/leopard.go
@@ -921,7 +921,11 @@ func fwht2(a, b *ffe) {
 
 // fwht2alt is as fwht2, but returns result.
 func fwht2alt(a, b ffe) (ffe, ffe) {
-	return addMod(a, b), subMod(a, b)
+	sum := uint(a) + uint(b)
+	dif := uint(a) - uint(b)
+	sum = sum + sum>>bitwidth
+	dif = dif + dif>>bitwidth
+	return ffe(sum), ffe(dif)
 }
 
 var initOnce sync.Once


### PR DESCRIPTION
Was playing around with improving fwht for Leopard16 reconstruction.

This was a minor improvement since it appears to avoid a register spill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal calculation efficiency through streamlined computational approach, maintaining existing functionality and public interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->