### PR TITLE
feat: add WorkAllocator option for external work buffer management

### DIFF
--- a/leopard.go
+++ b/leopard.go
@@ -37,7 +37,7 @@ type leopardFF16 struct {
 	parityShards int // Number of parity shards, should not be modified.
 	totalShards  int // Total number of shards. Calculated, and should not be modified.
 
-	workPool sync.Pool
+	workAlloc WorkAllocator
 
 	o options
 }
@@ -58,6 +58,7 @@ func newFF16(dataShards, parityShards int, opt options) (*leopardFF16, error) {
 		dataShards:   dataShards,
 		parityShards: parityShards,
 		totalShards:  dataShards + parityShards,
+		workAlloc:    opt.workAlloc,
 		o:            opt,
 	}
 	return r, nil
@@ -148,23 +149,8 @@ func (r *leopardFF16) encode(shards [][]byte) error {
 	}
 
 	m := ceilPow2(r.parityShards)
-	var work [][]byte
-	if w, ok := r.workPool.Get().([][]byte); ok {
-		work = w
-	}
-	if cap(work) >= m*2 {
-		work = work[:m*2]
-	} else {
-		work = AllocAligned(m*2, shardSize)
-	}
-	for i := range work {
-		if cap(work[i]) < shardSize {
-			work[i] = AllocAligned(1, shardSize)[0]
-		} else {
-			work[i] = work[i][:shardSize]
-		}
-	}
-	defer r.workPool.Put(work)
+	work := r.workAlloc.Get(m*2, shardSize)
+	defer r.workAlloc.Put(work)
 
 	mtrunc := min(r.dataShards, m)
 
@@ -472,23 +458,8 @@ func (r *leopardFF16) reconstruct(shards [][]byte, recoverAll bool) error {
 
 	fwht(&errLocs, order)
 
-	var work [][]byte
-	if w, ok := r.workPool.Get().([][]byte); ok {
-		work = w
-	}
-	if cap(work) >= n {
-		work = work[:n]
-	} else {
-		work = make([][]byte, n)
-	}
-	for i := range work {
-		if cap(work[i]) < shardSize {
-			work[i] = make([]byte, shardSize)
-		} else {
-			work[i] = work[i][:shardSize]
-		}
-	}
-	defer r.workPool.Put(work)
+	work := r.workAlloc.Get(n, shardSize)
+	defer r.workAlloc.Put(work)
 
 	// work <- recovery data
 

--- a/leopard8.go
+++ b/leopard8.go
@@ -24,7 +24,7 @@ type leopardFF8 struct {
 	parityShards int // Number of parity shards, should not be modified.
 	totalShards  int // Total number of shards. Calculated, and should not be modified.
 
-	workPool    sync.Pool
+	workAlloc   WorkAllocator
 	inversion   map[[inversion8Bytes]byte]leopardGF8cache
 	inversionMu sync.Mutex
 
@@ -54,6 +54,7 @@ func newFF8(dataShards, parityShards int, opt options) (*leopardFF8, error) {
 		dataShards:   dataShards,
 		parityShards: parityShards,
 		totalShards:  dataShards + parityShards,
+		workAlloc:    opt.workAlloc,
 		o:            opt,
 	}
 	if opt.inversionCache && (r.totalShards <= 64 || opt.forcedInversionCache) {
@@ -142,28 +143,8 @@ func (r *leopardFF8) encode(shards [][]byte) error {
 	}
 
 	m := ceilPow2(r.parityShards)
-	var work [][]byte
-	if w, ok := r.workPool.Get().([][]byte); ok {
-		work = w
-	} else {
-		work = AllocAligned(m*2, workSize8)
-	}
-	if cap(work) >= m*2 {
-		work = work[:m*2]
-		for i := range work {
-			if i >= r.parityShards {
-				if cap(work[i]) < workSize8 {
-					work[i] = AllocAligned(1, workSize8)[0]
-				} else {
-					work[i] = work[i][:workSize8]
-				}
-			}
-		}
-	} else {
-		work = AllocAligned(m*2, workSize8)
-	}
-
-	defer r.workPool.Put(work)
+	work := r.workAlloc.Get(m*2, workSize8)
+	defer r.workAlloc.Put(work)
 
 	mtrunc := min(r.dataShards, m)
 
@@ -531,28 +512,8 @@ func (r *leopardFF8) reconstruct(shards [][]byte, recoverAll bool) error {
 		}
 	}
 
-	var work [][]byte
-	if w, ok := r.workPool.Get().([][]byte); ok {
-		work = w
-	}
-	if cap(work) >= n {
-		work = work[:n]
-		for i := range work {
-			if cap(work[i]) < workSize8 {
-				work[i] = make([]byte, workSize8)
-			} else {
-				work[i] = work[i][:workSize8]
-			}
-		}
-
-	} else {
-		work = make([][]byte, n)
-		all := make([]byte, n*workSize8)
-		for i := range work {
-			work[i] = all[i*workSize8 : i*workSize8+workSize8]
-		}
-	}
-	defer r.workPool.Put(work)
+	work := r.workAlloc.Get(n, workSize8)
+	defer r.workAlloc.Put(work)
 
 	// work <- recovery data
 

--- a/options.go
+++ b/options.go
@@ -35,6 +35,7 @@ type options struct {
 	forcedInversionCache bool
 	customMatrix         [][]byte
 	withLeopard          leopardMode
+	workAlloc            WorkAllocator
 
 	// stream options
 	concReads  bool
@@ -300,6 +301,17 @@ func WithLeopardGF(enabled bool) Option {
 		} else {
 			o.withLeopard = leopardAsNeeded
 		}
+	}
+}
+
+// WithWorkAllocator sets an external allocator for the leopard encoder's
+// temporary work buffers. When provided, the encoder calls [WorkAllocator.Get]
+// and [WorkAllocator.Put] instead of using its internal sync.Pool.
+//
+// This has no effect on non-leopard encoders.
+func WithWorkAllocator(alloc WorkAllocator) Option {
+	return func(o *options) {
+		o.workAlloc = alloc
 	}
 }
 

--- a/reedsolomon.go
+++ b/reedsolomon.go
@@ -427,6 +427,9 @@ func New(dataShards, parityShards int, opts ...Option) (Encoder, error) {
 	for _, opt := range opts {
 		opt(&o)
 	}
+	if o.workAlloc == nil {
+		o.workAlloc = &defaultWorkAllocator{}
+	}
 
 	totShards := dataShards + parityShards
 	switch {

--- a/work_alloc.go
+++ b/work_alloc.go
@@ -1,0 +1,54 @@
+package reedsolomon
+
+import "sync"
+
+// WorkAllocator provides external work buffer management for the leopard
+// Reed-Solomon encoder (both GF(2^8) and GF(2^16) variants). When set via
+// [WithWorkAllocator], it replaces the internal sync.Pool used by the leopard
+// encoder for temporary work buffers during Encode and Reconstruct.
+//
+// This only affects the leopard-based encoder ([WithLeopardGF16], [WithLeopardGF]).
+// The classic matrix-based encoder does not use work buffers and ignores this option.
+//
+// This is useful when the caller wants to control buffer lifecycle (e.g., to
+// avoid sync.Pool churn under GC pressure with large buffers).
+//
+// Implementations must be safe for concurrent use: Get and Put may be
+// called from multiple goroutines when the encoder is shared.
+//
+// Get must return n byte slices, each with len and cap >= size.
+// Slices should be SIMD-aligned (64-byte) for optimal performance; see [AllocAligned].
+// Put is called when the work buffer is no longer needed.
+type WorkAllocator interface {
+	Get(n, size int) [][]byte
+	Put([][]byte)
+}
+
+// defaultWorkAllocator is the default WorkAllocator backed by sync.Pool.
+type defaultWorkAllocator struct {
+	pool sync.Pool
+}
+
+func (a *defaultWorkAllocator) Get(n, size int) [][]byte {
+	var work [][]byte
+	if w, ok := a.pool.Get().([][]byte); ok {
+		work = w
+	}
+	if cap(work) >= n {
+		work = work[:n]
+	} else {
+		work = AllocAligned(n, size)
+	}
+	for i := range work {
+		if cap(work[i]) < size {
+			work[i] = AllocAligned(1, size)[0]
+		} else {
+			work[i] = work[i][:size]
+		}
+	}
+	return work
+}
+
+func (a *defaultWorkAllocator) Put(work [][]byte) {
+	a.pool.Put(work)
+}


### PR DESCRIPTION
Add a WorkAllocator interface and WithWorkAllocator option that allows callers to provide their own work buffer allocation strategy for the leopard encoder (both GF(2^8) and GF(2^16) variants).

When set, the encoder calls WorkAllocator.Get/Put instead of its internal sync.Pool. This is useful for callers that need to control buffer lifecycle — for example, to avoid sync.Pool churn under GC pressure with large work buffers (the leopard encoder allocates 2×ceilPow2(parityShards)×shardSize bytes per Encode/Reconstruct call).

The classic matrix-based encoder does not use work buffers and ignores this option. When no WorkAllocator is provided, existing sync.Pool behavior is preserved (fully backward compatible).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a WorkAllocator interface and WithWorkAllocator option to support custom work-buffer allocation.
  * Now defaults to an internal allocator when none is provided.

* **Refactor**
  * Encode and Reconstruct delegate temporary workspace sizing and allocation to the configurable allocator, centralizing buffer management and reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->