### PR TITLE
feat: add `LowLevel.GF16MulSliceXor8` fused 8-scalar mul-XOR

### DIFF
--- a/mulgf16_xor8_amd64.go
+++ b/mulgf16_xor8_amd64.go
@@ -1,0 +1,82 @@
+//go:build !appengine && !noasm && !nogen && !nopshufb && gc
+
+package reedsolomon
+
+import (
+	"fmt"
+	"runtime"
+	"unsafe"
+)
+
+//go:noescape
+func mulgf16Xor8_gfni(col []byte, tables *[8 * 4]uint64, outs *[8]uintptr)
+
+// GF16MulSliceXor8 fuses 8 scalar-broadcast GF(2^16) mul-XOR accumulates
+// that share the same input slice `in`:
+//
+//	out_k[i] ^= scalars[k] * in[i]   for k in [0, 8)
+//
+// All 8 destination slices must share length with in, a non-zero multiple
+// of 64 bytes (Leopard's chunk size: 32 low bytes + 32 high bytes per chunk).
+// A zero scalar contributes nothing and is treated normally; callers do not
+// need to filter them.
+//
+// On GFNI hosts the fused kernel loads each input chunk into registers once
+// and applies all 8 scalars with unrolled VGF2P8AFFINEQB sequences. Other
+// amd64 hosts fall back to 8 independent AVX2 mul-XORs; non-amd64 / no-asm
+// builds fall back to the scalar refMulAdd.
+func (l LowLevel) GF16MulSliceXor8(scalars *[8]uint16, in []byte, outs *[8][]byte) {
+	if len(in) == 0 {
+		return
+	}
+	if len(in)%64 != 0 {
+		panic(fmt.Sprintf("reedsolomon: GF16MulSliceXor8: len(in)=%d must be a multiple of 64", len(in)))
+	}
+	for k := range outs {
+		if len(outs[k]) != len(in) {
+			panic(fmt.Sprintf("reedsolomon: GF16MulSliceXor8: outs[%d] has len %d, expected %d", k, len(outs[k]), len(in)))
+		}
+	}
+	initConstants()
+	opts := l.options()
+
+	if opts.useAvxGNFI && gf2p811dMulMatrices16 != nil {
+		var tables [8 * 4]uint64
+		anyNonZero := false
+		for k, c := range scalars {
+			if c == 0 {
+				// All-zero matrix: VGF2P8AFFINEQB yields zero, XOR is a no-op.
+				continue
+			}
+			anyNonZero = true
+			copy(tables[k*4:k*4+4], gf2p811dMulMatrices16[logLUT[ffe(c)]][:])
+		}
+		if !anyNonZero {
+			return
+		}
+		if raceEnabled {
+			raceReadSlice(in)
+			for k := range outs {
+				raceWriteSlice(outs[k])
+			}
+		}
+		var ptrs [8]uintptr
+		for k := range outs {
+			ptrs[k] = uintptr(unsafe.Pointer(&outs[k][0]))
+		}
+		mulgf16Xor8_gfni(in, &tables, &ptrs)
+		// outs holds the only Go-visible references to the destination
+		// backing arrays; ptrs stores only uintptr so GC cannot trace
+		// through it. Keep outs live across the asm call.
+		runtime.KeepAlive(outs)
+		return
+	}
+
+	// Fallback: per-scalar mul-XOR, reusing the AVX2/scalar mulgf16Xor.
+	for k, c := range scalars {
+		if c == 0 {
+			continue
+		}
+		mulgf16Xor(outs[k], in, logLUT[ffe(c)], opts)
+	}
+}

--- a/mulgf16_xor8_amd64.s
+++ b/mulgf16_xor8_amd64.s
@@ -1,0 +1,181 @@
+// Fused GF(2^16) mul-XOR kernel: given a single source column `col` and 8
+// scalars, produces 8 separate accumulate-XORs in one pass, reading `col`
+// once per 64-byte chunk instead of 8 times.
+//
+// out_k[i] ^= col[i] * scalar_k   for k in [0, 8)
+//
+// Leopard-formatted 64-byte chunks (32 low bytes + 32 high bytes).
+
+//go:build !appengine && !noasm && !nogen && !nopshufb && gc
+
+#include "textflag.h"
+
+// func mulgf16Xor8_gfni(col []byte, tables *[8 * 4]uint64, outs *[8]uintptr)
+// Requires: AVX, AVX2, GFNI
+// len(col) must be a positive multiple of 64.
+// tables must hold 8 contiguous [4]uint64 GFNI matrices (32 bytes each).
+// outs holds 8 pointers to destination buffers, each at least len(col) bytes.
+// On exit the 8 destination pointers are unchanged.
+TEXT ·mulgf16Xor8_gfni(SB), NOSPLIT, $0-40
+	MOVQ col_base+0(FP), DX
+	MOVQ col_len+8(FP), AX
+	MOVQ tables+24(FP), BX
+	MOVQ outs+32(FP), SI
+
+	// Load the 8 output base pointers into R8..R15.
+	MOVQ (SI), R8
+	MOVQ 8(SI), R9
+	MOVQ 16(SI), R10
+	MOVQ 24(SI), R11
+	MOVQ 32(SI), R12
+	MOVQ 40(SI), R13
+	MOVQ 48(SI), R14
+	MOVQ 56(SI), R15
+
+loop_mulgf16Xor8_gfni:
+	VMOVDQU (DX), Y0
+	VMOVDQU 32(DX), Y1
+
+	// k = 0
+	VBROADCASTSD   0(BX), Y2
+	VBROADCASTSD   8(BX), Y3
+	VBROADCASTSD   16(BX), Y4
+	VBROADCASTSD   24(BX), Y5
+	VGF2P8AFFINEQB $0x00, Y2, Y0, Y6
+	VGF2P8AFFINEQB $0x00, Y3, Y1, Y7
+	VGF2P8AFFINEQB $0x00, Y4, Y0, Y8
+	VGF2P8AFFINEQB $0x00, Y5, Y1, Y9
+	VPXOR          Y6, Y7, Y6
+	VPXOR          Y8, Y9, Y8
+	VPXOR          (R8), Y6, Y6
+	VPXOR          32(R8), Y8, Y8
+	VMOVDQU        Y6, (R8)
+	VMOVDQU        Y8, 32(R8)
+
+	// k = 1
+	VBROADCASTSD   32(BX), Y2
+	VBROADCASTSD   40(BX), Y3
+	VBROADCASTSD   48(BX), Y4
+	VBROADCASTSD   56(BX), Y5
+	VGF2P8AFFINEQB $0x00, Y2, Y0, Y6
+	VGF2P8AFFINEQB $0x00, Y3, Y1, Y7
+	VGF2P8AFFINEQB $0x00, Y4, Y0, Y8
+	VGF2P8AFFINEQB $0x00, Y5, Y1, Y9
+	VPXOR          Y6, Y7, Y6
+	VPXOR          Y8, Y9, Y8
+	VPXOR          (R9), Y6, Y6
+	VPXOR          32(R9), Y8, Y8
+	VMOVDQU        Y6, (R9)
+	VMOVDQU        Y8, 32(R9)
+
+	// k = 2
+	VBROADCASTSD   64(BX), Y2
+	VBROADCASTSD   72(BX), Y3
+	VBROADCASTSD   80(BX), Y4
+	VBROADCASTSD   88(BX), Y5
+	VGF2P8AFFINEQB $0x00, Y2, Y0, Y6
+	VGF2P8AFFINEQB $0x00, Y3, Y1, Y7
+	VGF2P8AFFINEQB $0x00, Y4, Y0, Y8
+	VGF2P8AFFINEQB $0x00, Y5, Y1, Y9
+	VPXOR          Y6, Y7, Y6
+	VPXOR          Y8, Y9, Y8
+	VPXOR          (R10), Y6, Y6
+	VPXOR          32(R10), Y8, Y8
+	VMOVDQU        Y6, (R10)
+	VMOVDQU        Y8, 32(R10)
+
+	// k = 3
+	VBROADCASTSD   96(BX), Y2
+	VBROADCASTSD   104(BX), Y3
+	VBROADCASTSD   112(BX), Y4
+	VBROADCASTSD   120(BX), Y5
+	VGF2P8AFFINEQB $0x00, Y2, Y0, Y6
+	VGF2P8AFFINEQB $0x00, Y3, Y1, Y7
+	VGF2P8AFFINEQB $0x00, Y4, Y0, Y8
+	VGF2P8AFFINEQB $0x00, Y5, Y1, Y9
+	VPXOR          Y6, Y7, Y6
+	VPXOR          Y8, Y9, Y8
+	VPXOR          (R11), Y6, Y6
+	VPXOR          32(R11), Y8, Y8
+	VMOVDQU        Y6, (R11)
+	VMOVDQU        Y8, 32(R11)
+
+	// k = 4
+	VBROADCASTSD   128(BX), Y2
+	VBROADCASTSD   136(BX), Y3
+	VBROADCASTSD   144(BX), Y4
+	VBROADCASTSD   152(BX), Y5
+	VGF2P8AFFINEQB $0x00, Y2, Y0, Y6
+	VGF2P8AFFINEQB $0x00, Y3, Y1, Y7
+	VGF2P8AFFINEQB $0x00, Y4, Y0, Y8
+	VGF2P8AFFINEQB $0x00, Y5, Y1, Y9
+	VPXOR          Y6, Y7, Y6
+	VPXOR          Y8, Y9, Y8
+	VPXOR          (R12), Y6, Y6
+	VPXOR          32(R12), Y8, Y8
+	VMOVDQU        Y6, (R12)
+	VMOVDQU        Y8, 32(R12)
+
+	// k = 5
+	VBROADCASTSD   160(BX), Y2
+	VBROADCASTSD   168(BX), Y3
+	VBROADCASTSD   176(BX), Y4
+	VBROADCASTSD   184(BX), Y5
+	VGF2P8AFFINEQB $0x00, Y2, Y0, Y6
+	VGF2P8AFFINEQB $0x00, Y3, Y1, Y7
+	VGF2P8AFFINEQB $0x00, Y4, Y0, Y8
+	VGF2P8AFFINEQB $0x00, Y5, Y1, Y9
+	VPXOR          Y6, Y7, Y6
+	VPXOR          Y8, Y9, Y8
+	VPXOR          (R13), Y6, Y6
+	VPXOR          32(R13), Y8, Y8
+	VMOVDQU        Y6, (R13)
+	VMOVDQU        Y8, 32(R13)
+
+	// k = 6
+	VBROADCASTSD   192(BX), Y2
+	VBROADCASTSD   200(BX), Y3
+	VBROADCASTSD   208(BX), Y4
+	VBROADCASTSD   216(BX), Y5
+	VGF2P8AFFINEQB $0x00, Y2, Y0, Y6
+	VGF2P8AFFINEQB $0x00, Y3, Y1, Y7
+	VGF2P8AFFINEQB $0x00, Y4, Y0, Y8
+	VGF2P8AFFINEQB $0x00, Y5, Y1, Y9
+	VPXOR          Y6, Y7, Y6
+	VPXOR          Y8, Y9, Y8
+	VPXOR          (R14), Y6, Y6
+	VPXOR          32(R14), Y8, Y8
+	VMOVDQU        Y6, (R14)
+	VMOVDQU        Y8, 32(R14)
+
+	// k = 7
+	VBROADCASTSD   224(BX), Y2
+	VBROADCASTSD   232(BX), Y3
+	VBROADCASTSD   240(BX), Y4
+	VBROADCASTSD   248(BX), Y5
+	VGF2P8AFFINEQB $0x00, Y2, Y0, Y6
+	VGF2P8AFFINEQB $0x00, Y3, Y1, Y7
+	VGF2P8AFFINEQB $0x00, Y4, Y0, Y8
+	VGF2P8AFFINEQB $0x00, Y5, Y1, Y9
+	VPXOR          Y6, Y7, Y6
+	VPXOR          Y8, Y9, Y8
+	VPXOR          (R15), Y6, Y6
+	VPXOR          32(R15), Y8, Y8
+	VMOVDQU        Y6, (R15)
+	VMOVDQU        Y8, 32(R15)
+
+	// Advance all pointers by 64.
+	ADDQ $64, R8
+	ADDQ $64, R9
+	ADDQ $64, R10
+	ADDQ $64, R11
+	ADDQ $64, R12
+	ADDQ $64, R13
+	ADDQ $64, R14
+	ADDQ $64, R15
+	ADDQ $64, DX
+	SUBQ $64, AX
+	JNZ  loop_mulgf16Xor8_gfni
+
+	VZEROUPPER
+	RET

--- a/mulgf16_xor8_noasm.go
+++ b/mulgf16_xor8_noasm.go
@@ -1,0 +1,29 @@
+//go:build !amd64 || appengine || noasm || nogen || nopshufb || !gc
+
+package reedsolomon
+
+import "fmt"
+
+// GF16MulSliceXor8 is the portable scalar fallback. See the amd64 variant
+// for full semantics.
+func (l LowLevel) GF16MulSliceXor8(scalars *[8]uint16, in []byte, outs *[8][]byte) {
+	if len(in) == 0 {
+		return
+	}
+	if len(in)%64 != 0 {
+		panic(fmt.Sprintf("reedsolomon: GF16MulSliceXor8: len(in)=%d must be a multiple of 64", len(in)))
+	}
+	for k := range outs {
+		if len(outs[k]) != len(in) {
+			panic(fmt.Sprintf("reedsolomon: GF16MulSliceXor8: outs[%d] has len %d, expected %d", k, len(outs[k]), len(in)))
+		}
+	}
+	initConstants()
+	opts := l.options()
+	for k, c := range scalars {
+		if c == 0 {
+			continue
+		}
+		mulgf16Xor(outs[k], in, logLUT[ffe(c)], opts)
+	}
+}

--- a/mulgf16_xor8_test.go
+++ b/mulgf16_xor8_test.go
@@ -1,0 +1,147 @@
+package reedsolomon
+
+import (
+	"math/rand/v2"
+	"testing"
+)
+
+// naiveGF16MulSliceXor8 computes out_k[i] ^= scalars[k] * in[i] over
+// Leopard-formatted chunks using the scalar GF16Mul. Used as correctness
+// oracle for GF16MulSliceXor8.
+func naiveGF16MulSliceXor8(ll LowLevel, scalars *[8]uint16, in []byte, outs *[8][]byte) {
+	for off := 0; off < len(in); off += 64 {
+		for j := 0; j < 32; j++ {
+			inSym := uint16(in[off+32+j])<<8 | uint16(in[off+j])
+			for k := 0; k < 8; k++ {
+				dst := outs[k]
+				outSym := uint16(dst[off+32+j])<<8 | uint16(dst[off+j])
+				res := outSym ^ ll.GF16Mul(scalars[k], inSym)
+				dst[off+j] = byte(res)
+				dst[off+32+j] = byte(res >> 8)
+			}
+		}
+	}
+}
+
+func TestGF16MulSliceXor8(t *testing.T) {
+	var ll LowLevel
+	initConstants()
+
+	sizes := []int{64, 128, 256, 2048}
+	r := rand.New(rand.NewPCG(7, 42))
+
+	for _, sz := range sizes {
+		in := make([]byte, sz)
+		for i := range in {
+			in[i] = byte(r.IntN(256))
+		}
+		// Include at least one zero scalar to cover the no-op short-circuit.
+		var scalars [8]uint16
+		for k := range scalars {
+			scalars[k] = uint16(r.IntN(65536))
+		}
+		scalars[3] = 0
+
+		outs, ref := newOutputPair(sz, r)
+		ll.GF16MulSliceXor8(&scalars, in, &outs)
+		naiveGF16MulSliceXor8(ll, &scalars, in, &ref)
+		assertOutputsEqual(t, sz, outs, ref)
+	}
+}
+
+// TestGF16MulSliceXor8PanicsOnLengthMismatch checks that the precondition
+// (every outs[k] has len(in)) is enforced at the entry of the function, so
+// callers that violate it get a clear panic instead of memory corruption in
+// the asm kernel.
+func TestGF16MulSliceXor8PanicsOnLengthMismatch(t *testing.T) {
+	var ll LowLevel
+	initConstants()
+
+	sz := 64
+	in := make([]byte, sz)
+	scalars := [8]uint16{1, 2, 3, 4, 5, 6, 7, 8}
+
+	var outs [8][]byte
+	for k := 0; k < 8; k++ {
+		outs[k] = make([]byte, sz)
+	}
+	outs[3] = outs[3][:sz-1] // wrong length
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on mismatched outs length, got nil")
+		}
+	}()
+	ll.GF16MulSliceXor8(&scalars, in, &outs)
+}
+
+// TestMulgf16Xor exercises both internal paths of the mulgf16Xor kernel
+// that GF16MulSliceXor8 relies on when the fused GFNI kernel is not taken:
+// the AVX2 scalar-broadcast path (useAVX2=true) and the pure-Go refMulAdd
+// path (useAVX2=false, matching the noasm build).
+func TestMulgf16Xor(t *testing.T) {
+	initConstants()
+
+	for _, tc := range []struct {
+		name    string
+		useAVX2 bool
+	}{
+		{"avx2", true},
+		{"scalar", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.useAVX2 && !defaultOptions.useAVX2 {
+				t.Skip("host does not support AVX2")
+			}
+			opts := defaultOptions
+			opts.useAVX2 = tc.useAVX2
+
+			r := rand.New(rand.NewPCG(9, 11))
+			sz := 256
+			in := make([]byte, sz)
+			for i := range in {
+				in[i] = byte(r.IntN(256))
+			}
+			scalars := [8]uint16{0x1234, 0, 0xFFFF, 1, 2, 0xABCD, 0x5555, 0xAAAA}
+
+			outs, ref := newOutputPair(sz, r)
+			for k, c := range scalars {
+				if c == 0 {
+					continue
+				}
+				mulgf16Xor(outs[k], in, logLUT[ffe(c)], &opts)
+			}
+
+			var ll LowLevel
+			naiveGF16MulSliceXor8(ll, &scalars, in, &ref)
+			assertOutputsEqual(t, sz, outs, ref)
+		})
+	}
+}
+
+// newOutputPair returns two identical pairs of 8 destination buffers of the
+// requested size, each pre-filled with random bytes.
+func newOutputPair(sz int, r *rand.Rand) (a, b [8][]byte) {
+	for k := 0; k < 8; k++ {
+		a[k] = make([]byte, sz)
+		b[k] = make([]byte, sz)
+		for i := 0; i < sz; i++ {
+			v := byte(r.IntN(256))
+			a[k][i] = v
+			b[k][i] = v
+		}
+	}
+	return a, b
+}
+
+func assertOutputsEqual(t *testing.T, sz int, got, want [8][]byte) {
+	t.Helper()
+	for k := 0; k < 8; k++ {
+		for i := 0; i < sz; i++ {
+			if got[k][i] != want[k][i] {
+				t.Fatalf("size=%d k=%d byte %d: got=%02x want=%02x",
+					sz, k, i, got[k][i], want[k][i])
+			}
+		}
+	}
+}

--- a/mulgf16_xor_amd64.go
+++ b/mulgf16_xor_amd64.go
@@ -1,0 +1,28 @@
+//go:build !appengine && !noasm && !nogen && !nopshufb && gc
+
+package reedsolomon
+
+//go:noescape
+func mulgf16Xor_avx2(x []byte, y []byte, table *[128]uint8)
+
+// mulgf16Xor does out[:] ^= in[:] * scalar, where scalar is given by its log.
+// Slices must have equal length that is a non-zero multiple of 64.
+//
+// There is no GFNI variant here on purpose: the fused 8-scalar kernel
+// (mulgf16Xor8_gfni) covers the GFNI fast path, so this function is only
+// reached on hosts without GFNI. AVX2 is the best we can do there.
+func mulgf16Xor(out, in []byte, log_m ffe, o *options) {
+	if len(out) == 0 {
+		return
+	}
+	if o.useAVX2 {
+		tmp := &multiply256LUT[log_m]
+		if raceEnabled {
+			raceReadSlice(in)
+			raceWriteSlice(out)
+		}
+		mulgf16Xor_avx2(out, in, tmp)
+		return
+	}
+	refMulAdd(out, in, log_m)
+}

--- a/mulgf16_xor_amd64.s
+++ b/mulgf16_xor_amd64.s
@@ -1,0 +1,61 @@
+// AVX2 scalar-broadcast GF(2^16) mul-accumulate: out[:] ^= in[:] * scalar.
+// Used as the inner kernel by the non-GFNI fallback path of
+// GF16MulSliceXor8 — GFNI hosts take the fused 8-scalar kernel instead.
+// Leopard-formatted 64-byte chunks (32 low bytes + 32 high bytes).
+
+//go:build !appengine && !noasm && !nogen && !nopshufb && gc
+
+#include "textflag.h"
+
+// func mulgf16Xor_avx2(x []byte, y []byte, table *[128]uint8)
+// Requires: AVX, AVX2, SSE2
+TEXT ·mulgf16Xor_avx2(SB), NOSPLIT, $0-56
+	MOVQ           table+48(FP), AX
+	VBROADCASTI128 (AX), Y0
+	VBROADCASTI128 64(AX), Y1
+	VBROADCASTI128 16(AX), Y2
+	VBROADCASTI128 80(AX), Y3
+	VBROADCASTI128 32(AX), Y4
+	VBROADCASTI128 96(AX), Y5
+	VBROADCASTI128 48(AX), Y6
+	VBROADCASTI128 112(AX), Y7
+	MOVQ           x_len+8(FP), AX
+	MOVQ           x_base+0(FP), CX
+	MOVQ           y_base+24(FP), DX
+	MOVQ           $0x0000000f, BX
+	MOVQ           BX, X8
+	VPBROADCASTB   X8, Y8
+
+loop_mulgf16Xor_avx2:
+	VMOVDQU (DX), Y9
+	VMOVDQU 32(DX), Y10
+	VPSRLQ  $0x04, Y9, Y11
+	VPAND   Y8, Y9, Y9
+	VPAND   Y8, Y11, Y11
+	VPSHUFB Y9, Y0, Y12
+	VPSHUFB Y9, Y1, Y9
+	VPSHUFB Y11, Y2, Y13
+	VPSHUFB Y11, Y3, Y11
+	VPXOR   Y12, Y13, Y12
+	VPXOR   Y9, Y11, Y9
+	VPAND   Y10, Y8, Y11
+	VPSRLQ  $0x04, Y10, Y10
+	VPAND   Y8, Y10, Y10
+	VPSHUFB Y11, Y4, Y13
+	VPSHUFB Y11, Y5, Y11
+	VPXOR   Y12, Y13, Y12
+	VPXOR   Y9, Y11, Y9
+	VPSHUFB Y10, Y6, Y13
+	VPSHUFB Y10, Y7, Y11
+	VPXOR   Y12, Y13, Y12
+	VPXOR   Y9, Y11, Y9
+	VPXOR   (CX), Y12, Y12
+	VPXOR   32(CX), Y9, Y9
+	VMOVDQU Y12, (CX)
+	VMOVDQU Y9, 32(CX)
+	ADDQ    $0x40, CX
+	ADDQ    $0x40, DX
+	SUBQ    $0x40, AX
+	JNZ     loop_mulgf16Xor_avx2
+	VZEROUPPER
+	RET

--- a/mulgf16_xor_noasm.go
+++ b/mulgf16_xor_noasm.go
@@ -1,0 +1,11 @@
+//go:build !amd64 || appengine || noasm || nogen || nopshufb || !gc
+
+package reedsolomon
+
+// mulgf16Xor does out[:] ^= in[:] * scalar via the scalar reference path.
+func mulgf16Xor(out, in []byte, log_m ffe, _ *options) {
+	if len(out) == 0 {
+		return
+	}
+	refMulAdd(out, in, log_m)
+}


### PR DESCRIPTION
> The entirety of this change is generated by Claude Opus 4.7, and I do not fully understand the assembly part to the level I am comfortable with. However, the correctness tests added here and at the usage level both confirm that this is indeed equivalent to the preexisting behavior, yet ~30x faster. The previous `LowLevel.GF16Mul` was the dominant CPU consumer in the profiles, and now its effictively invisible.

Applies 8 scalar-broadcast GF(2^16) mul-XOR accumulates that share the same input slice in a single pass:

    out_k[i] ^= scalars[k] * in[i]   for k in 0..8

On GFNI hosts the fused kernel loads each 64-byte input chunk into Y registers once and unrolls 8 mul-XOR sequences with destination pointers kept in R8..R15, eliminating the 7 redundant input reloads and loop preambles that 8 independent per-scalar mul-XORs would pay. Other amd64 hosts fall back to an internal AVX2 scalar-broadcast kernel (mulgf16Xor_avx2) applied 8 times; non-amd64 / no-asm builds fall back to refMulAdd.

This matches the access pattern of applying a GF128 coefficient vector (8 GF16 components) to a shared column of GF16 values, which is the hot inner step of RLC / matrix-multiply workloads over GF(2^16).

Measured impact, wired into the random-linear-combination step of celestia-app's rsema1d codec (128 MB input, K=1024, 128 KB rows) on an AMD Ryzen 9 7940HS (Zen 4, GFNI):

                            scalar baseline    fused kernel    speedup
    1 worker                   56 MB/s          1540 MB/s       ~27x
    16 workers                371 MB/s         10290 MB/s       ~28x

Same kernel, used to batch-verify proofs against a shared commitment, drops per-proof verify cost from ~3.6 ms to ~0.1 ms (~34x) at batch sizes of a few hundred.

Closes #332 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an 8-way GF(16) multiply-and-XOR batch operation with GFNI-accelerated path on supported x86-64, AVX2-optimized kernel, and portable fallbacks.
  * Improved single-buffer GF(16) multiply-and-XOR with AVX2 acceleration and scalar fallback.

* **Tests**
  * Added comprehensive tests for multiple sizes, per-lane scalars (including zero lanes), length-mismatch panic behavior, and both accelerated and fallback implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->