### PR TITLE
gf16: More cache friendly encoding/decoding of bigger shards

### DIFF
--- a/leopard.go
+++ b/leopard.go
@@ -142,6 +142,25 @@ func (r *leopardFF16) Encode(shards [][]byte) error {
 	return r.encode(shards)
 }
 
+// encodeChunkSize returns the chunk size for the given shard size and m.
+// It tries to keep the working set in L3 cache.
+func encodeChunkSize(shardSize, m int) int {
+	l3 := cpuid.CPU.Cache.L3
+	if l3 <= 0 {
+		l3 = 16 << 20
+	}
+	// Target: m*2 work buffers fit in ~2/3 of L3.
+	chunkSize := l3 * 2 / (m * 2 * 3)
+	chunkSize &^= 63 // 64-byte alignment
+	if chunkSize < 4<<10 {
+		return shardSize
+	}
+	if chunkSize >= shardSize {
+		return shardSize
+	}
+	return chunkSize
+}
+
 func (r *leopardFF16) encode(shards [][]byte) error {
 	shardSize := shardSize(shards)
 	if shardSize%64 != 0 {
@@ -149,80 +168,118 @@ func (r *leopardFF16) encode(shards [][]byte) error {
 	}
 
 	m := ceilPow2(r.parityShards)
-	work := r.workAlloc.Get(m*2, shardSize)
-	defer r.workAlloc.Put(work)
-
 	mtrunc := min(r.dataShards, m)
+	lastCount := r.dataShards % m
+
+	chunkSize := encodeChunkSize(shardSize, m)
+
+	work := r.workAlloc.Get(m*2, chunkSize)
+	defer r.workAlloc.Put(work)
 
 	skewLUT := fftSkew[m-1:]
 
-	sh := shards
+	if chunkSize >= shardSize {
+		// No chunking — zero-overhead path.
+		r.encodeChunk(shards[:r.dataShards], shards, mtrunc, lastCount, m, work, skewLUT)
+
+		for i, w := range work[:r.parityShards] {
+			sh := shards[i+r.dataShards]
+			if cap(sh) >= shardSize {
+				sh = append(sh[:0], w...)
+			} else {
+				sh = w
+			}
+			shards[i+r.dataShards] = sh
+		}
+		return nil
+	}
+
+	// Process in cache-friendly chunks.
+	// wMod is a copy of the work slice headers we can safely modify.
+	// The original work retains allocator-owned pointers for Put.
+	sh := make([][]byte, len(shards))
+	wMod := make([][]byte, len(work))
+	copy(wMod, work)
+	for off := 0; off < shardSize; off += chunkSize {
+		work := wMod
+		sh := sh
+		end := off + chunkSize
+		if end > shardSize {
+			end = shardSize
+			sz := end - off
+			for i := range work {
+				work[i] = work[i][:sz]
+			}
+		}
+		for i := range shards {
+			sh[i] = shards[i][off:end]
+		}
+
+		// Write parity directly into output slices.
+		res := shards[r.dataShards:r.totalShards]
+		for i := range res {
+			work[i] = res[i][off:end]
+		}
+
+		r.encodeChunk(sh[:r.dataShards], sh, mtrunc, lastCount, m, work, skewLUT)
+	}
+	return nil
+}
+
+func (r *leopardFF16) encodeChunk(data [][]byte, sh [][]byte, mtrunc, lastCount, m int, work [][]byte, skewLUT []ffe) {
 	ifftDITEncoder(
-		sh[:r.dataShards],
+		data,
 		mtrunc,
 		work,
-		nil, // No xor output
+		nil,
 		m,
 		skewLUT,
 		&r.o,
 	)
 
-	lastCount := r.dataShards % m
 	if m >= r.dataShards {
 		goto skip_body
 	}
 
-	// For sets of m data pieces:
-	for i := m; i+m <= r.dataShards; i += m {
-		sh = sh[m:]
-		skewLUT = skewLUT[m:]
+	{
+		sh := sh
+		skewLUT := skewLUT
+		// For sets of m data pieces:
+		for i := m; i+m <= r.dataShards; i += m {
+			sh = sh[m:]
+			skewLUT = skewLUT[m:]
 
-		// work <- work xor IFFT(data + i, m, m + i)
+			// work <- work xor IFFT(data + i, m, m + i)
+			ifftDITEncoder(
+				sh,
+				m,
+				work[m:],
+				work,
+				m,
+				skewLUT,
+				&r.o,
+			)
+		}
 
-		ifftDITEncoder(
-			sh, // data source
-			m,
-			work[m:], // temporary workspace
-			work,     // xor destination
-			m,
-			skewLUT,
-			&r.o,
-		)
-	}
+		// Handle final partial set of m pieces:
+		if lastCount != 0 {
+			sh = sh[m:]
+			skewLUT = skewLUT[m:]
 
-	// Handle final partial set of m pieces:
-	if lastCount != 0 {
-		sh = sh[m:]
-		skewLUT = skewLUT[m:]
-
-		// work <- work xor IFFT(data + i, m, m + i)
-
-		ifftDITEncoder(
-			sh, // data source
-			lastCount,
-			work[m:], // temporary workspace
-			work,     // xor destination
-			m,
-			skewLUT,
-			&r.o,
-		)
+			ifftDITEncoder(
+				sh,
+				lastCount,
+				work[m:],
+				work,
+				m,
+				skewLUT,
+				&r.o,
+			)
+		}
 	}
 
 skip_body:
-	// work <- FFT(work, m, 0)
 	fftDIT(work, r.parityShards, m, fftSkew[:], &r.o)
-
-	for i, w := range work[:r.parityShards] {
-		sh := shards[i+r.dataShards]
-		if cap(sh) >= shardSize {
-			sh = append(sh[:0], w...)
-		} else {
-			sh = w
-		}
-		shards[i+r.dataShards] = sh
-	}
-
-	return nil
 }
 
 func (r *leopardFF16) EncodeIdx(dataShard []byte, idx int, parity [][]byte) error {

--- a/leopard.go
+++ b/leopard.go
@@ -1273,6 +1273,7 @@ func (r *leopardFF16) getShardSlice() [][]byte {
 }
 
 func (r *leopardFF16) putShardSlice(s [][]byte) {
+	clear(s)
 	r.shardSlicePool.Put(s)
 }
 
@@ -1284,6 +1285,7 @@ func (r *leopardFF16) getWorkSlice(n int) [][]byte {
 }
 
 func (r *leopardFF16) putWorkSlice(s [][]byte) {
+	clear(s)
 	r.workSlicePool.Put(s)
 }
 

--- a/leopard.go
+++ b/leopard.go
@@ -1273,7 +1273,7 @@ func (r *leopardFF16) getShardSlice() [][]byte {
 }
 
 func (r *leopardFF16) putShardSlice(s [][]byte) {
-	clear(s)
+	clear(s[:cap(s)])
 	r.shardSlicePool.Put(s)
 }
 
@@ -1285,7 +1285,7 @@ func (r *leopardFF16) getWorkSlice(n int) [][]byte {
 }
 
 func (r *leopardFF16) putWorkSlice(s [][]byte) {
-	clear(s)
+	clear(s[:cap(s)])
 	r.workSlicePool.Put(s)
 }
 

--- a/leopard.go
+++ b/leopard.go
@@ -489,7 +489,7 @@ func (r *leopardFF16) reconstruct(shards [][]byte, recoverAll bool) error {
 	}
 
 	if LEO_ERROR_BITFIELD_OPT && useBits {
-		errorBits.prepare()
+		errorBits.prepare(n)
 	}
 
 	// Evaluate error locator polynomial
@@ -1301,6 +1301,10 @@ type errorBitfield struct {
 	Words        [kWordMips][kWords]uint64
 	BigWords     [kBigMips][kBigWords]uint64
 	BiggestWords [kBiggestMips]uint64
+	// neededFns holds pre-computed needed-check functions indexed sequentially
+	// for each FFT layer, allocated once in prepare to avoid per-call closure allocs.
+	// Max 9 entries: mipLevel 16 down to 0 by 2.
+	neededFns [9]func(int) bool
 }
 
 func (e *errorBitfield) set(i int) {
@@ -1359,8 +1363,7 @@ var kHiMasks = [5]uint64{
 	0xFFFF0000FFFF0000,
 }
 
-func (e *errorBitfield) prepare() {
-	// First mip level is for final layer of FFT: pairs of data
+func (e *errorBitfield) prepare(m int) {
 	for i := range kWords {
 		w_i := e.Words[0][i]
 		hi2lo0 := w_i | ((w_i & kHiMasks[0]) >> 1)
@@ -1388,13 +1391,13 @@ func (e *errorBitfield) prepare() {
 		}
 		e.BigWords[0][i] = w_i
 
-		bits := 1
+		shift := 1
 		for j := 1; j < kBigMips; j++ {
-			hi2lo_j := w_i | ((w_i & kHiMasks[j-1]) >> bits)
-			lo2hi_j := (w_i & (kHiMasks[j-1] >> bits)) << bits
+			hi2lo_j := w_i | ((w_i & kHiMasks[j-1]) >> shift)
+			lo2hi_j := (w_i & (kHiMasks[j-1] >> shift)) << shift
 			w_i = hi2lo_j | lo2hi_j
 			e.BigWords[j][i] = w_i
-			bits <<= 1
+			shift <<= 1
 		}
 	}
 
@@ -1406,24 +1409,33 @@ func (e *errorBitfield) prepare() {
 	}
 	e.BiggestWords[0] = w_i
 
-	bits := uint64(1)
+	shift := uint64(1)
 	for j := 1; j < kBiggestMips; j++ {
-		hi2lo_j := w_i | ((w_i & kHiMasks[j-1]) >> bits)
-		lo2hi_j := (w_i & (kHiMasks[j-1] >> bits)) << bits
+		hi2lo_j := w_i | ((w_i & kHiMasks[j-1]) >> shift)
+		lo2hi_j := (w_i & (kHiMasks[j-1] >> shift)) << shift
 		w_i = hi2lo_j | lo2hi_j
 		e.BiggestWords[j] = w_i
-		bits <<= 1
+		shift <<= 1
+	}
+
+	// Pre-compute needed-check functions for used mip levels.
+	// fftDIT starts at bits.Len32(n)-1 and decrements by 2.
+	// We store them sequentially from index 0.
+	startLevel := bits.Len32(uint32(m)) - 1
+	for i, ml := 0, startLevel; ml >= 0; i, ml = i+1, ml-2 {
+		e.neededFns[i] = e.isNeededFn(ml)
 	}
 }
 
 func (e *errorBitfield) fftDIT(work [][]byte, mtrunc, m int, skewLUT []ffe, o *options) {
 	// Decimation in time: Unroll 2 layers at a time
-	mipLevel := bits.Len32(uint32(m)) - 1
+	fnIdx := 0
 
 	dist4 := m
 	dist := m >> 2
-	needed := e.isNeededFn(mipLevel)
 	for dist != 0 {
+		needed := e.neededFns[fnIdx]
+		fnIdx++
 		// For each set of dist*4 elements:
 		for r := 0; r < mtrunc; r += dist4 {
 			if !needed(r) {
@@ -1447,12 +1459,11 @@ func (e *errorBitfield) fftDIT(work [][]byte, mtrunc, m int, skewLUT []ffe, o *o
 		}
 		dist4 = dist
 		dist >>= 2
-		mipLevel -= 2
-		needed = e.isNeededFn(mipLevel)
 	}
 
 	// If there is one layer left:
 	if dist4 == 2 {
+		needed := e.neededFns[fnIdx]
 		for r := 0; r < mtrunc; r += 2 {
 			if !needed(r) {
 				continue

--- a/leopard.go
+++ b/leopard.go
@@ -147,16 +147,17 @@ func (r *leopardFF16) Encode(shards [][]byte) error {
 	return r.encode(shards)
 }
 
-// encodeChunkSize returns the chunk size for the given shard size and m.
-// It tries to keep the working set in L3 cache, capped at maxWorkSize16.
-func encodeChunkSize(shardSize, m int) int {
+// encodeChunkSize returns the chunk size for the given shard size and
+// number of work buffers. It tries to keep the working set in L3 cache,
+// capped at maxWorkSize16.
+func encodeChunkSize(shardSize, workBufs int) int {
 	l3 := cpuid.CPU.Cache.L3
 	if l3 <= 0 {
 		// Assume 16MB L3 if not detected.
 		l3 = 16 << 20
 	}
-	// Target: m*2 work buffers fit in ~2/3 of L3.
-	chunkSize := l3 * 2 / (m * 2 * 3)
+	// Target: workBufs * chunkSize fits in ~2/3 of L3.
+	chunkSize := l3 * 2 / (workBufs * 3)
 	chunkSize = min(chunkSize, maxWorkSize16)
 	chunkSize &^= 63 // 64-byte alignment
 	if chunkSize < 4<<10 {
@@ -174,7 +175,7 @@ func (r *leopardFF16) encode(shards [][]byte) error {
 	m := ceilPow2(r.parityShards)
 	mtrunc := min(r.dataShards, m)
 	lastCount := r.dataShards % m
-	chunkSize := encodeChunkSize(shardSize, m)
+	chunkSize := encodeChunkSize(shardSize, m*2)
 
 	work := r.workAlloc.Get(m*2, chunkSize)
 	defer r.workAlloc.Put(work)
@@ -529,7 +530,7 @@ func (r *leopardFF16) reconstruct(shards [][]byte, recoverAll bool) error {
 	}
 
 	if chunkSize >= shardSize {
-		r.reconstructChunk(sh, shards, work, m, n, errLocs, useBits, &errorBits, recoverAll)
+		r.reconstructChunk(sh, shards, work, m, n, &errLocs, useBits, &errorBits, recoverAll)
 		return nil
 	}
 
@@ -563,7 +564,7 @@ func (r *leopardFF16) reconstruct(shards [][]byte, recoverAll bool) error {
 			}
 		}
 
-		r.reconstructChunk(shChunk, outChunk, work, m, n, errLocs, useBits, &errorBits, recoverAll)
+		r.reconstructChunk(shChunk, outChunk, work, m, n, &errLocs, useBits, &errorBits, recoverAll)
 	}
 	return nil
 }
@@ -571,7 +572,7 @@ func (r *leopardFF16) reconstruct(shards [][]byte, recoverAll bool) error {
 // reconstructChunk processes one chunk of the reconstruct pipeline.
 // sh has nil entries for missing shards (used for presence checks).
 // out has allocated entries for all shards (used for writing output).
-func (r *leopardFF16) reconstructChunk(sh, out [][]byte, work [][]byte, m, n int, errLocs [order]ffe, useBits bool, errorBits *errorBitfield, recoverAll bool) {
+func (r *leopardFF16) reconstructChunk(sh, out [][]byte, work [][]byte, m, n int, errLocs *[order]ffe, useBits bool, errorBits *errorBitfield, recoverAll bool) {
 	const LEO_ERROR_BITFIELD_OPT = true
 	outputCount := m + r.dataShards
 

--- a/leopard.go
+++ b/leopard.go
@@ -20,7 +20,8 @@ import (
 	"github.com/klauspost/cpuid/v2"
 )
 
-const maxZeroBufferSize16 = 1 << 20 // 1MB
+const maxWorkSize16 = 64 << 10 // Cap for GF16 chunk size.
+const maxZeroBufferSize16 = maxWorkSize16
 
 var zeroBufferPool16Once sync.Once
 var zeroBufferPool16Buf *[maxZeroBufferSize16]byte
@@ -38,6 +39,10 @@ type leopardFF16 struct {
 	totalShards  int // Total number of shards. Calculated, and should not be modified.
 
 	workAlloc WorkAllocator
+
+	// Pools for slice header arrays, avoiding per-call allocations.
+	shardSlicePool sync.Pool // [][]byte of len totalShards
+	workSlicePool  sync.Pool // [][]byte — sized at first use
 
 	o options
 }
@@ -143,22 +148,21 @@ func (r *leopardFF16) Encode(shards [][]byte) error {
 }
 
 // encodeChunkSize returns the chunk size for the given shard size and m.
-// It tries to keep the working set in L3 cache.
+// It tries to keep the working set in L3 cache, capped at maxWorkSize16.
 func encodeChunkSize(shardSize, m int) int {
 	l3 := cpuid.CPU.Cache.L3
 	if l3 <= 0 {
+		// Assume 16MB L3 if not detected.
 		l3 = 16 << 20
 	}
 	// Target: m*2 work buffers fit in ~2/3 of L3.
 	chunkSize := l3 * 2 / (m * 2 * 3)
+	chunkSize = min(chunkSize, maxWorkSize16)
 	chunkSize &^= 63 // 64-byte alignment
 	if chunkSize < 4<<10 {
-		return shardSize
+		chunkSize = 4 << 10
 	}
-	if chunkSize >= shardSize {
-		return shardSize
-	}
-	return chunkSize
+	return min(chunkSize, shardSize)
 }
 
 func (r *leopardFF16) encode(shards [][]byte) error {
@@ -170,7 +174,6 @@ func (r *leopardFF16) encode(shards [][]byte) error {
 	m := ceilPow2(r.parityShards)
 	mtrunc := min(r.dataShards, m)
 	lastCount := r.dataShards % m
-
 	chunkSize := encodeChunkSize(shardSize, m)
 
 	work := r.workAlloc.Get(m*2, chunkSize)
@@ -178,27 +181,10 @@ func (r *leopardFF16) encode(shards [][]byte) error {
 
 	skewLUT := fftSkew[m-1:]
 
-	if chunkSize >= shardSize {
-		// No chunking — zero-overhead path.
-		r.encodeChunk(shards[:r.dataShards], shards, mtrunc, lastCount, m, work, skewLUT)
-
-		for i, w := range work[:r.parityShards] {
-			sh := shards[i+r.dataShards]
-			if cap(sh) >= shardSize {
-				sh = append(sh[:0], w...)
-			} else {
-				sh = w
-			}
-			shards[i+r.dataShards] = sh
-		}
-		return nil
-	}
-
-	// Process in cache-friendly chunks.
-	// wMod is a copy of the work slice headers we can safely modify.
-	// The original work retains allocator-owned pointers for Put.
-	sh := make([][]byte, len(shards))
-	wMod := make([][]byte, len(work))
+	sh := r.getShardSlice()
+	defer r.putShardSlice(sh)
+	wMod := r.getWorkSlice(len(work))
+	defer r.putWorkSlice(wMod)
 	copy(wMod, work)
 	for off := 0; off < shardSize; off += chunkSize {
 		work := wMod
@@ -515,68 +501,18 @@ func (r *leopardFF16) reconstruct(shards [][]byte, recoverAll bool) error {
 
 	fwht(&errLocs, order)
 
-	work := r.workAlloc.Get(n, shardSize)
+	chunkSize := encodeChunkSize(shardSize, n)
+
+	work := r.workAlloc.Get(n, chunkSize)
 	defer r.workAlloc.Put(work)
 
-	// work <- recovery data
+	// sh preserves the original nil entries so reconstructChunk can
+	// distinguish present vs missing shards after pre-allocation.
+	sh := r.getShardSlice()
+	defer r.putShardSlice(sh)
+	copy(sh, shards)
 
-	for i := 0; i < r.parityShards; i++ {
-		if len(shards[i+r.dataShards]) != 0 {
-			mulgf16(work[i], shards[i+r.dataShards], errLocs[i], &r.o)
-		} else {
-			clear(work[i])
-		}
-	}
-	for i := r.parityShards; i < m; i++ {
-		clear(work[i])
-	}
-
-	// work <- original data
-
-	for i := 0; i < r.dataShards; i++ {
-		if len(shards[i]) != 0 {
-			mulgf16(work[m+i], shards[i], errLocs[m+i], &r.o)
-		} else {
-			clear(work[m+i])
-		}
-	}
-	for i := m + r.dataShards; i < n; i++ {
-		clear(work[i])
-	}
-
-	// work <- IFFT(work, n, 0)
-
-	ifftDITDecoder(
-		m+r.dataShards,
-		work,
-		n,
-		fftSkew[:],
-		&r.o,
-	)
-
-	// work <- FormalDerivative(work, n)
-
-	for i := 1; i < n; i++ {
-		width := ((i ^ (i - 1)) + 1) >> 1
-		slicesXor(work[i-width:i], work[i:i+width], &r.o)
-	}
-
-	// work <- FFT(work, n, 0) truncated to m + dataShards
-
-	outputCount := m + r.dataShards
-
-	if LEO_ERROR_BITFIELD_OPT && useBits {
-		errorBits.fftDIT(work, outputCount, n, fftSkew[:], &r.o)
-	} else {
-		fftDIT(work, outputCount, n, fftSkew[:], &r.o)
-	}
-
-	// Reveal erasures
-	//
-	//  Original = -ErrLocator * FFT( Derivative( IFFT( ErrLocator * ReceivedData ) ) )
-	//  mul_mem(x, y, log_m, ) equals x[] = y[] * log_m
-	//
-	// mem layout: [Recovery Data (Power of Two = M)] [Original Data (K)] [Zero Padding out to N]
+	// Pre-allocate missing output shards.
 	end := r.dataShards
 	if recoverAll {
 		end = r.totalShards
@@ -590,15 +526,116 @@ func (r *leopardFF16) reconstruct(shards [][]byte, recoverAll bool) error {
 		} else {
 			shards[i] = make([]byte, shardSize)
 		}
-		if i >= r.dataShards {
-			// Parity shard.
-			mulgf16(shards[i], work[i-r.dataShards], modulus-errLocs[i-r.dataShards], &r.o)
-		} else {
-			// Data shard.
-			mulgf16(shards[i], work[i+m], modulus-errLocs[i+m], &r.o)
+	}
+
+	if chunkSize >= shardSize {
+		r.reconstructChunk(sh, shards, work, m, n, errLocs, useBits, &errorBits, recoverAll)
+		return nil
+	}
+
+	// Process in cache-friendly chunks.
+	wMod := r.getWorkSlice(len(work))
+	defer r.putWorkSlice(wMod)
+	copy(wMod, work)
+	shChunk := r.getShardSlice()
+	defer r.putShardSlice(shChunk)
+	copy(shChunk, sh)
+	outChunk := r.getShardSlice()
+	defer r.putShardSlice(outChunk)
+	for off := 0; off < shardSize; off += chunkSize {
+		work := wMod
+		shChunk := shChunk
+		outChunk := outChunk
+		endSlice := off + chunkSize
+		if endSlice > shardSize {
+			endSlice = shardSize
+			sz := endSlice - off
+			for i := range work {
+				work[i] = work[i][:sz]
+			}
 		}
+		for i := range shards {
+			if len(sh[i]) != 0 {
+				shChunk[i] = shards[i][off:endSlice]
+			}
+			if len(shards[i]) != 0 {
+				outChunk[i] = shards[i][off:endSlice]
+			}
+		}
+
+		r.reconstructChunk(shChunk, outChunk, work, m, n, errLocs, useBits, &errorBits, recoverAll)
 	}
 	return nil
+}
+
+// reconstructChunk processes one chunk of the reconstruct pipeline.
+// sh has nil entries for missing shards (used for presence checks).
+// out has allocated entries for all shards (used for writing output).
+func (r *leopardFF16) reconstructChunk(sh, out [][]byte, work [][]byte, m, n int, errLocs [order]ffe, useBits bool, errorBits *errorBitfield, recoverAll bool) {
+	const LEO_ERROR_BITFIELD_OPT = true
+	outputCount := m + r.dataShards
+
+	// work <- recovery data
+	for i := 0; i < r.parityShards; i++ {
+		if len(sh[i+r.dataShards]) != 0 {
+			mulgf16(work[i], sh[i+r.dataShards], errLocs[i], &r.o)
+		} else {
+			clear(work[i])
+		}
+	}
+	for i := r.parityShards; i < m; i++ {
+		clear(work[i])
+	}
+
+	// work <- original data
+	for i := 0; i < r.dataShards; i++ {
+		if len(sh[i]) != 0 {
+			mulgf16(work[m+i], sh[i], errLocs[m+i], &r.o)
+		} else {
+			clear(work[m+i])
+		}
+	}
+	for i := m + r.dataShards; i < n; i++ {
+		clear(work[i])
+	}
+
+	// work <- IFFT(work, n, 0)
+	ifftDITDecoder(
+		m+r.dataShards,
+		work,
+		n,
+		fftSkew[:],
+		&r.o,
+	)
+
+	// work <- FormalDerivative(work, n)
+	for i := 1; i < n; i++ {
+		width := ((i ^ (i - 1)) + 1) >> 1
+		slicesXor(work[i-width:i], work[i:i+width], &r.o)
+	}
+
+	// work <- FFT(work, n, 0) truncated to m + dataShards
+	if LEO_ERROR_BITFIELD_OPT && useBits {
+		errorBits.fftDIT(work, outputCount, n, fftSkew[:], &r.o)
+	} else {
+		fftDIT(work, outputCount, n, fftSkew[:], &r.o)
+	}
+
+	// Reveal erasures
+	end := r.dataShards
+	if recoverAll {
+		end = r.totalShards
+	}
+	for i := 0; i < end; i++ {
+		if len(sh[i]) != 0 {
+			continue
+		}
+		if i >= r.dataShards {
+			mulgf16(out[i], work[i-r.dataShards], modulus-errLocs[i-r.dataShards], &r.o)
+		} else {
+			mulgf16(out[i], work[i+m], modulus-errLocs[i+m], &r.o)
+		}
+	}
 }
 
 // Basic no-frills version for decoder
@@ -1226,6 +1263,28 @@ func initMul16LUT() {
 			gf2p811dMulMatrices16[logM] = [4]uint64{A, B, C, D}
 		}
 	}
+}
+
+func (r *leopardFF16) getShardSlice() [][]byte {
+	if s, ok := r.shardSlicePool.Get().([][]byte); ok {
+		return s[:r.totalShards]
+	}
+	return make([][]byte, r.totalShards)
+}
+
+func (r *leopardFF16) putShardSlice(s [][]byte) {
+	r.shardSlicePool.Put(s)
+}
+
+func (r *leopardFF16) getWorkSlice(n int) [][]byte {
+	if s, ok := r.workSlicePool.Get().([][]byte); ok && cap(s) >= n {
+		return s[:n]
+	}
+	return make([][]byte, n)
+}
+
+func (r *leopardFF16) putWorkSlice(s [][]byte) {
+	r.workSlicePool.Put(s)
 }
 
 const kWordMips = 5

--- a/reedsolomon_test.go
+++ b/reedsolomon_test.go
@@ -1354,9 +1354,15 @@ func BenchmarkEncodeLeopardGF16Chunking(b *testing.B) {
 		{500, 500},
 		{50, 20},
 	} {
+		const maxBytes = 1 << 30
 		for _, sz := range []int{
 			64 << 10, 256 << 10, 1 << 20, 4 << 20, 16 << 20,
 		} {
+			sz = min(sz, maxBytes/(tc.data+tc.parity))
+			sz = sz / 64 * 64
+			if sz == 0 {
+				continue
+			}
 			name := fmt.Sprintf("%dx%d/%dK", tc.data, tc.parity, sz>>10)
 			b.Run(name, func(b *testing.B) {
 				benchmarkEncode(b, tc.data, tc.parity, sz, WithLeopardGF16(true))

--- a/reedsolomon_test.go
+++ b/reedsolomon_test.go
@@ -1345,6 +1345,26 @@ func BenchmarkEncode_8x8x32M(b *testing.B) { benchmarkEncode(b, 8, 8, 32*1024*10
 func BenchmarkEncode_24x8x24M(b *testing.B) { benchmarkEncode(b, 24, 8, 24*1024*1024) }
 func BenchmarkEncode_24x8x48M(b *testing.B) { benchmarkEncode(b, 24, 8, 48*1024*1024) }
 
+func BenchmarkEncodeLeopardGF16Chunking(b *testing.B) {
+	// Tests GF16 encoder across shard sizes where L3 cache chunking matters.
+	for _, tc := range []struct {
+		data, parity int
+	}{
+		{800, 200},
+		{500, 500},
+		{50, 20},
+	} {
+		for _, sz := range []int{
+			64 << 10, 256 << 10, 1 << 20, 4 << 20, 16 << 20,
+		} {
+			name := fmt.Sprintf("%dx%d/%dK", tc.data, tc.parity, sz>>10)
+			b.Run(name, func(b *testing.B) {
+				benchmarkEncode(b, tc.data, tc.parity, sz, WithLeopardGF16(true))
+			})
+		}
+	}
+}
+
 func benchmarkVerify(b *testing.B, dataShards, parityShards, shardSize int) {
 	r, err := New(dataShards, parityShards, testOptions(WithAutoGoroutines(shardSize))...)
 	if err != nil {


### PR DESCRIPTION
Split GF16 encoding/decoding of large shards into jobs that are more likely to stay within CPU cache.


```
goos: windows
goarch: amd64
pkg: github.com/klauspost/reedsolomon
cpu: AMD Ryzen 9 9950X 16-Core Processor            
                                  │  before.txt  │             after.txt              │
                                  │    sec/op    │   sec/op     vs base               │
Encode800x200/64-32                  11.25µ ± 5%   11.62µ ± 3%   +3.26% (p=0.003 n=8)
Encode800x200/256-32                 19.65µ ± 3%   18.59µ ± 1%   -5.41% (p=0.000 n=8)
Encode800x200/1024-32                58.78µ ± 1%   54.80µ ± 1%   -6.77% (p=0.000 n=8)
Encode800x200/4096-32                242.0µ ± 1%   226.7µ ± 3%   -6.32% (p=0.000 n=8)
Encode800x200/16384-32              1112.8µ ± 2%   965.3µ ± 5%  -13.26% (p=0.000 n=8)
Encode800x200/65536-32               8.161m ± 6%   4.865m ± 2%  -40.39% (p=0.000 n=8)
Encode800x200/262144-32              54.63m ± 4%   28.75m ± 1%  -47.38% (p=0.000 n=8)
Encode800x200/1048576-32             245.4m ± 2%   121.8m ± 1%  -50.38% (p=0.000 n=8)
EncodeLeopard/83840-32              11.908m ± 9%   7.294m ± 2%  -38.74% (p=0.000 n=8)
EncodeLeopard50x20x1M-32             3.782m ± 5%   3.438m ± 1%   -9.09% (p=0.000 n=8)
Encode_8x8x8M-32                     3.459m ± 3%   3.024m ± 1%  -12.56% (p=0.000 n=8)
Encode_24x8x48M-32                   36.29m ± 5%   33.50m ± 0%   -7.70% (p=0.000 n=8)
Reconstruct800x200/64-32             467.9µ ± 2%   444.7µ ± 1%   -4.96% (p=0.000 n=8)
Reconstruct800x200/256-32            507.5µ ± 1%   482.2µ ± 1%   -4.99% (p=0.000 n=8)
Reconstruct800x200/1024-32           723.4µ ± 2%   682.4µ ± 1%   -5.67% (p=0.000 n=8)
Reconstruct800x200/4096-32           1.602m ± 2%   1.502m ± 0%   -6.24% (p=0.000 n=8)
Reconstruct800x200/16384-32          7.840m ± 4%   5.215m ± 1%  -33.48% (p=0.000 n=8)
Reconstruct800x200/65536-32          57.29m ± 3%   19.96m ± 1%  -65.16% (p=0.000 n=8)
Reconstruct800x200/262144-32        263.55m ± 3%   78.47m ± 1%  -70.23% (p=0.000 n=8)
Reconstruct800x200/1048576-32       1179.4m ± 5%   316.3m ± 2%  -73.18% (p=0.000 n=8)
ReconstructLeopard50x20x1M-32        14.14m ± 2%   13.15m ± 1%   -6.98% (p=0.000 n=8)
Reconstruct10x4x16M-32               4.184m ± 1%   3.759m ± 1%  -10.16% (p=0.000 n=8)
ReconstructData800x200/64-32         476.2µ ± 3%   441.0µ ± 1%   -7.39% (p=0.000 n=8)
ReconstructData800x200/256-32        520.8µ ± 1%   482.7µ ± 1%   -7.32% (p=0.000 n=8)
ReconstructData800x200/1024-32       741.9µ ± 2%   678.2µ ± 1%   -8.59% (p=0.000 n=8)
ReconstructData800x200/4096-32       1.604m ± 1%   1.500m ± 1%   -6.45% (p=0.000 n=8)
ReconstructData800x200/16384-32      8.164m ± 3%   5.208m ± 1%  -36.21% (p=0.000 n=8)
ReconstructData800x200/65536-32      57.20m ± 6%   19.74m ± 1%  -65.49% (p=0.000 n=8)
ReconstructData800x200/262144-32    266.58m ± 4%   77.40m ± 2%  -70.97% (p=0.000 n=8)
ReconstructData800x200/1048576-32   1223.8m ± 7%   312.6m ± 4%  -74.46% (p=0.000 n=8)
geomean                              4.766m        3.218m       -32.47%

                                  │  before.txt   │               after.txt               │
                                  │      B/s      │      B/s       vs base                │
Encode800x200/64-32                 5.299Gi ±  4%    5.132Gi ± 5%    -3.16% (p=0.003 n=8)
Encode800x200/256-32                12.13Gi ±  5%    12.83Gi ± 1%    +5.72% (p=0.000 n=8)
Encode800x200/1024-32               16.22Gi ±  1%    17.40Gi ± 2%    +7.26% (p=0.000 n=8)
Encode800x200/4096-32               15.76Gi ±  2%    16.83Gi ± 1%    +6.75% (p=0.000 n=8)
Encode800x200/16384-32              13.71Gi ±  3%    15.81Gi ± 2%   +15.28% (p=0.000 n=8)
Encode800x200/65536-32              7.479Gi ±  9%   12.546Gi ± 4%   +67.75% (p=0.000 n=8)
Encode800x200/262144-32             4.469Gi ±  6%    8.492Gi ± 1%   +90.04% (p=0.000 n=8)
Encode800x200/1048576-32            3.980Gi ±  2%    8.021Gi ± 1%  +101.54% (p=0.000 n=8)
EncodeLeopard/83840-32              6.557Gi ±  8%   10.704Gi ± 1%   +63.24% (p=0.000 n=8)
EncodeLeopard50x20x1M-32            18.08Gi ±  8%    19.89Gi ± 2%   +10.00% (p=0.000 n=8)
Encode_8x8x8M-32                    36.14Gi ±  4%    41.33Gi ± 1%   +14.36% (p=0.000 n=8)
Encode_24x8x48M-32                  41.33Gi ± 16%    44.78Gi ± 1%    +8.34% (p=0.000 n=8)
Reconstruct800x200/64-32            130.5Mi ±  1%    137.3Mi ± 1%    +5.22% (p=0.000 n=8)
Reconstruct800x200/256-32           481.1Mi ±  1%    506.3Mi ± 1%    +5.25% (p=0.000 n=8)
Reconstruct800x200/1024-32          1.318Gi ±  2%    1.398Gi ± 2%    +6.00% (p=0.000 n=8)
Reconstruct800x200/4096-32          2.382Gi ±  1%    2.540Gi ± 1%    +6.66% (p=0.000 n=8)
Reconstruct800x200/16384-32         1.946Gi ±  4%    2.926Gi ± 1%   +50.32% (p=0.000 n=8)
Reconstruct800x200/65536-32         1.065Gi ±  7%    3.058Gi ± 1%  +187.00% (p=0.000 n=8)
Reconstruct800x200/262144-32        948.6Mi ±  3%   3186.0Mi ± 1%  +235.87% (p=0.000 n=8)
Reconstruct800x200/1048576-32       847.9Mi ±  4%   3161.5Mi ± 2%  +272.87% (p=0.000 n=8)
ReconstructLeopard50x20x1M-32       4.836Gi ±  2%    5.198Gi ± 1%    +7.50% (p=0.000 n=8)
Reconstruct10x4x16M-32              52.28Gi ±  2%    58.19Gi ± 1%   +11.31% (p=0.000 n=8)
ReconstructData800x200/64-32        128.2Mi ±  2%    138.4Mi ± 2%    +7.97% (p=0.000 n=8)
ReconstructData800x200/256-32       468.8Mi ±  1%    505.8Mi ± 1%    +7.89% (p=0.000 n=8)
ReconstructData800x200/1024-32      1.285Gi ±  1%    1.406Gi ± 1%    +9.40% (p=0.000 n=8)
ReconstructData800x200/4096-32      2.379Gi ±  1%    2.543Gi ± 1%    +6.90% (p=0.000 n=8)
ReconstructData800x200/16384-32     1.869Gi ± 10%    2.930Gi ± 1%   +56.77% (p=0.000 n=8)
ReconstructData800x200/65536-32     1.067Gi ±  9%    3.092Gi ± 1%  +189.78% (p=0.000 n=8)
ReconstructData800x200/262144-32    937.8Mi ±  5%   3230.1Mi ± 1%  +244.43% (p=0.000 n=8)
ReconstructData800x200/1048576-32   817.1Mi ±  4%   3199.4Mi ± 2%  +291.54% (p=0.000 n=8)
geomean                             2.931Gi          4.341Gi        +48.09%

                                  │   before.txt    │               after.txt               │
                                  │      B/op       │     B/op       vs base                │
Encode800x200/64-32                     24.00 ±  0%     72.00 ±  0%  +200.00% (p=0.000 n=8)
Encode800x200/256-32                    24.00 ±  0%     72.00 ±  0%  +200.00% (p=0.000 n=8)
Encode800x200/1024-32                   28.00 ± 14%     72.00 ± 11%  +157.14% (p=0.000 n=8)
Encode800x200/4096-32                   24.00 ±  0%     72.00 ±  0%  +200.00% (p=0.001 n=8)
Encode800x200/16384-32                  24.00 ±  0%     72.00 ±  0%  +200.00% (p=0.001 n=8)
Encode800x200/65536-32                  24.00 ±  0%     72.00 ±  0%  +200.00% (p=0.000 n=8)
Encode800x200/262144-32                 24.00 ±  0%     72.00 ±  0%  +200.00% (p=0.000 n=8)
Encode800x200/1048576-32                24.00 ±  0%     72.00 ±  0%  +200.00% (p=0.000 n=8)
EncodeLeopard/83840-32                  24.00 ±  0%     72.00 ±  0%  +200.00% (p=0.000 n=8)
EncodeLeopard50x20x1M-32              3.528Ki ±  0%   3.527Ki ±  0%    -0.03% (p=0.001 n=8)
Encode_8x8x8M-32                      1.208Ki ±  1%   1.206Ki ±  1%         ~ (p=0.547 n=8)
Encode_24x8x48M-32                    2.031Ki ±  3%   2.057Ki ±  1%         ~ (p=0.493 n=8)
Reconstruct800x200/64-32              48.19Ki ±  0%   48.22Ki ±  0%         ~ (p=0.124 n=8)
Reconstruct800x200/256-32             48.47Ki ±  0%   48.50Ki ±  0%         ~ (p=0.382 n=8)
Reconstruct800x200/1024-32            49.56Ki ±  1%   49.74Ki ±  2%         ~ (p=0.817 n=8)
Reconstruct800x200/4096-32            55.54Ki ±  7%   54.97Ki ±  6%    -1.03% (p=0.050 n=8)
Reconstruct800x200/16384-32          152.77Ki ± 32%   64.29Ki ± 24%   -57.92% (p=0.000 n=8)
Reconstruct800x200/65536-32          2389.7Ki ±  7%   109.5Ki ±  1%   -95.42% (p=0.000 n=8)
Reconstruct800x200/262144-32        40382.6Ki ±  8%   304.7Ki ±  9%   -99.25% (p=0.000 n=8)
Reconstruct800x200/1048576-32       682.733Mi ±  0%   1.124Mi ±  0%   -99.84% (p=0.000 n=8)
ReconstructLeopard50x20x1M-32         18.23Ki ±  1%   17.29Ki ±  1%    -5.16% (p=0.000 n=8)
Reconstruct10x4x16M-32                2.771Ki ±  1%   2.752Ki ±  1%         ~ (p=0.246 n=8)
ReconstructData800x200/64-32          48.22Ki ±  0%   48.23Ki ±  0%         ~ (p=0.504 n=8)
ReconstructData800x200/256-32         48.48Ki ±  0%   48.49Ki ±  0%         ~ (p=0.959 n=8)
ReconstructData800x200/1024-32        49.72Ki ±  1%   49.75Ki ±  1%         ~ (p=0.878 n=8)
ReconstructData800x200/4096-32        55.56Ki ±  7%   55.12Ki ±  6%         ~ (p=0.328 n=8)
ReconstructData800x200/16384-32      122.50Ki ± 19%   64.03Ki ±  1%   -47.73% (p=0.000 n=8)
ReconstructData800x200/65536-32      2348.7Ki ±  8%   109.0Ki ±  0%   -95.36% (p=0.000 n=8)
ReconstructData800x200/262144-32    42063.2Ki ± 11%   298.9Ki ±  7%   -99.29% (p=0.000 n=8)
ReconstructData800x200/1048576-32   682.733Mi ±  0%   1.124Mi ± 16%   -99.84% (p=0.000 n=8)
geomean                               13.18Ki         6.621Ki         -49.76%

                                  │ before.txt  │               after.txt               │
                                  │  allocs/op  │  allocs/op   vs base                  │
Encode800x200/64-32                 1.000 ±  0%   3.000 ±  0%  +200.00% (p=0.000 n=8)
Encode800x200/256-32                1.000 ±  0%   3.000 ±  0%  +200.00% (p=0.000 n=8)
Encode800x200/1024-32               1.000 ±  0%   3.000 ±  0%  +200.00% (p=0.000 n=8)
Encode800x200/4096-32               1.000 ±  0%   3.000 ±  0%  +200.00% (p=0.000 n=8)
Encode800x200/16384-32              1.000 ±  0%   3.000 ±  0%  +200.00% (p=0.000 n=8)
Encode800x200/65536-32              1.000 ±  0%   3.000 ±  0%  +200.00% (p=0.000 n=8)
Encode800x200/262144-32             1.000 ±  0%   3.000 ±  0%  +200.00% (p=0.000 n=8)
Encode800x200/1048576-32            1.000 ±  0%   3.000 ±  0%  +200.00% (p=0.000 n=8)
EncodeLeopard/83840-32              1.000 ±  0%   3.000 ±  0%  +200.00% (p=0.000 n=8)
EncodeLeopard50x20x1M-32            3.000 ±  0%   3.000 ±  0%         ~ (p=1.000 n=8) ¹
Encode_8x8x8M-32                    7.000 ±  0%   7.000 ±  0%         ~ (p=1.000 n=8) ¹
Encode_24x8x48M-32                  11.00 ±  0%   11.00 ±  0%         ~ (p=1.000 n=8) ¹
Reconstruct800x200/64-32            3.000 ±  0%   4.000 ±  0%   +33.33% (p=0.000 n=8)
Reconstruct800x200/256-32           3.000 ±  0%   4.000 ±  0%   +33.33% (p=0.000 n=8)
Reconstruct800x200/1024-32          3.000 ±  0%   4.000 ±  0%   +33.33% (p=0.000 n=8)
Reconstruct800x200/4096-32          3.000 ±  0%   4.000 ±  0%   +33.33% (p=0.000 n=8)
Reconstruct800x200/16384-32         3.000 ±  0%   7.000 ±  0%  +133.33% (p=0.000 n=8)
Reconstruct800x200/65536-32         3.000 ±  0%   7.000 ±  0%  +133.33% (p=0.000 n=8)
Reconstruct800x200/262144-32        3.000 ± 33%   7.000 ± 14%  +133.33% (p=0.000 n=8)
Reconstruct800x200/1048576-32       5.000 ± 40%   8.000 ± 12%   +60.00% (p=0.000 n=8)
ReconstructLeopard50x20x1M-32       3.000 ±  0%   3.000 ±  0%         ~ (p=1.000 n=8) ¹
Reconstruct10x4x16M-32              26.00 ±  4%   25.00 ±  4%         ~ (p=0.101 n=8)
ReconstructData800x200/64-32        3.000 ±  0%   4.000 ±  0%   +33.33% (p=0.000 n=8)
ReconstructData800x200/256-32       3.000 ±  0%   4.000 ±  0%   +33.33% (p=0.000 n=8)
ReconstructData800x200/1024-32      3.000 ±  0%   4.000 ±  0%   +33.33% (p=0.000 n=8)
ReconstructData800x200/4096-32      3.000 ±  0%   4.000 ±  0%   +33.33% (p=0.000 n=8)
ReconstructData800x200/16384-32     3.000 ±  0%   7.000 ±  0%  +133.33% (p=0.000 n=8)
ReconstructData800x200/65536-32     3.000 ± 33%   7.000 ±  0%  +133.33% (p=0.000 n=8)
ReconstructData800x200/262144-32    4.000 ± 25%   7.500 ±  7%   +87.50% (p=0.000 n=8)
ReconstructData800x200/1048576-32   4.000 ± 25%   8.000 ± 12%  +100.00% (p=0.000 n=8)
geomean                             2.583         4.734         +83.30%
¹ all samples are equal
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Encoding and recovery now use cache-aligned, chunked processing with pooled buffers to boost throughput, lower memory peaks, and reduce per-call allocations; reconstruction now runs chunked, preserving input shard layout and avoiding extra allocations.
* **Tests**
  * Added benchmarks exercising the GF(16) encoder across multiple data/parity configurations and shard sizes to measure chunked performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->