### PR TITLE
leopard: use sparse FFT for data-only recovery

### DIFF
--- a/leopard.go
+++ b/leopard.go
@@ -445,8 +445,12 @@ func (r *leopardFF16) reconstruct(shards [][]byte, recoverAll bool) error {
 		return nil
 	}
 
-	// Use only if we are missing less than 1/4 parity.
-	useBits := r.totalShards-numberPresent <= r.parityShards/4
+	// Use only if the requested reconstruction set is sparse. ReconstructData
+	// ignores missing parity shards, so gating this on total missing shards
+	// disables the sparse FFT path for data-only recovery with many absent
+	// parity shards. Data-only recovery computes at most dataShards outputs
+	// from m+dataShards possible FFT outputs, so use the sparse path there.
+	useBits := !recoverAll || r.totalShards-numberPresent <= r.parityShards/4
 
 	// Check if we have enough to reconstruct.
 	if numberPresent < r.dataShards {

--- a/reedsolomon_test.go
+++ b/reedsolomon_test.go
@@ -1523,6 +1523,12 @@ func BenchmarkReconstructLeopard50x20x1M(b *testing.B) {
 	benchmarkReconstruct(b, 50, 20, 1024*1024, WithLeopardGF(true), WithInversionCache(true))
 }
 
+func BenchmarkReconstructDataLeopardGF16(b *testing.B) {
+	b.Run("sparse-data-only", func(b *testing.B) {
+		benchmarkReconstructDataSparse(b, 1024, 3072, 4096, WithLeopardGF16(true))
+	})
+}
+
 // Benchmark 10 data slices with 4 parity slices holding 16MB bytes each
 func BenchmarkReconstruct10x4x16M(b *testing.B) {
 	benchmarkReconstruct(b, 10, 4, 16*1024*1024)
@@ -1559,6 +1565,44 @@ func benchmarkReconstructData(b *testing.B, dataShards, parityShards, shardSize 
 
 		err = r.ReconstructData(shards)
 		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func benchmarkReconstructDataSparse(b *testing.B, dataShards, parityShards, shardSize int, opts ...Option) {
+	o := []Option{WithAutoGoroutines(shardSize)}
+	o = append(o, opts...)
+	r, err := New(dataShards, parityShards, testOptions(o...)...)
+	if err != nil {
+		b.Fatal(err)
+	}
+	shards := r.(Extensions).AllocAligned(shardSize)
+
+	for s := range dataShards {
+		fillRandom(shards[s])
+	}
+	if err := r.Encode(shards); err != nil {
+		b.Fatal(err)
+	}
+
+	presentData := dataShards / 4
+	presentParity := dataShards - presentData
+	if presentParity > parityShards {
+		b.Fatalf("need %d parity shards, have %d", presentParity, parityShards)
+	}
+	for s := dataShards + presentParity; s < dataShards+parityShards; s++ {
+		shards[s] = nil
+	}
+
+	b.SetBytes(int64(shardSize * (dataShards + parityShards)))
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for s := presentData; s < dataShards; s++ {
+			shards[s] = shards[s][:0]
+		}
+		if err := r.ReconstructData(shards); err != nil {
 			b.Fatal(err)
 		}
 	}


### PR DESCRIPTION
ReconstructData only needs original data shards. For Leopard GF16, the sparse FFT gate was based on total missing shards, so callers that supplied enough mixed data/parity shards but omitted many parity shards fell back to the dense FFT path even though parity outputs were not requested.

Treat data-only reconstruction as a sparse output request and keep the old total-missing heuristic for full Reconstruct.

Adds BenchmarkReconstructDataLeopardGF16/sparse-data-only to cover this general API shape: enough shards are present to recover data, but most parity shards are absent.

Benchmark on AMD Ryzen AI 9 HX 370, GOMAXPROCS=1:

before: 26.817-38.033 ms/op, 441-626 MB/s, 49.2 KB/op, 3 allocs/op

after:  15.777-27.322 ms/op, 614-1063 MB/s, 49.4 KB/op, 10 allocs/op

Command: GOMAXPROCS=1 GOCACHE=/tmp/go-build-reedsolomon go test . -run=^$ -bench='^BenchmarkReconstructDataLeopardGF16$/^sparse-data-only$' -benchmem -benchtime=5x -count=10 -timeout=10m

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a benchmark targeting sparse-data reconstruction scenarios to measure performance at large shard counts.

* **Chores**
  * Adjusted reconstruction path gating to more broadly route sparse reconstruction cases, improving performance and efficiency for large and sparsely-missing shard recoveries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klauspost/reedsolomon/pull/340?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->