### PR TITLE
leopard: bound decoder IFFT input for reconstruction

### DIFF
--- a/leopard.go
+++ b/leopard.go
@@ -445,8 +445,12 @@ func (r *leopardFF16) reconstruct(shards [][]byte, recoverAll bool) error {
 		return nil
 	}
 
-	// Use only if we are missing less than 1/4 parity.
-	useBits := r.totalShards-numberPresent <= r.parityShards/4
+	// Use only if the requested reconstruction set is sparse. ReconstructData
+	// ignores missing parity shards, so gating this on total missing shards
+	// disables the sparse FFT path for data-only recovery with many absent
+	// parity shards. Data-only recovery computes at most dataShards outputs
+	// from m+dataShards possible FFT outputs, so use the sparse path there.
+	useBits := !recoverAll || r.totalShards-numberPresent <= r.parityShards/4
 
 	// Check if we have enough to reconstruct.
 	if numberPresent < r.dataShards {

--- a/leopard.go
+++ b/leopard.go
@@ -470,6 +470,7 @@ func (r *leopardFF16) reconstruct(shards [][]byte, recoverAll bool) error {
 	// Fill in error locations.
 	var errorBits errorBitfield
 	var errLocs [order]ffe
+	inputCount := r.parityShards
 	for i := 0; i < r.parityShards; i++ {
 		if len(shards[i+r.dataShards]) == 0 {
 			errLocs[i] = 1
@@ -490,6 +491,8 @@ func (r *leopardFF16) reconstruct(shards [][]byte, recoverAll bool) error {
 			if LEO_ERROR_BITFIELD_OPT {
 				errorBits.set(i + m)
 			}
+		} else {
+			inputCount = m + i + 1
 		}
 	}
 
@@ -534,7 +537,7 @@ func (r *leopardFF16) reconstruct(shards [][]byte, recoverAll bool) error {
 	}
 
 	if chunkSize >= shardSize {
-		r.reconstructChunk(sh, shards, work, m, n, &errLocs, useBits, &errorBits, recoverAll)
+		r.reconstructChunk(sh, shards, work, m, n, inputCount, &errLocs, useBits, &errorBits, recoverAll)
 		return nil
 	}
 
@@ -568,7 +571,7 @@ func (r *leopardFF16) reconstruct(shards [][]byte, recoverAll bool) error {
 			}
 		}
 
-		r.reconstructChunk(shChunk, outChunk, work, m, n, &errLocs, useBits, &errorBits, recoverAll)
+		r.reconstructChunk(shChunk, outChunk, work, m, n, inputCount, &errLocs, useBits, &errorBits, recoverAll)
 	}
 	return nil
 }
@@ -576,7 +579,7 @@ func (r *leopardFF16) reconstruct(shards [][]byte, recoverAll bool) error {
 // reconstructChunk processes one chunk of the reconstruct pipeline.
 // sh has nil entries for missing shards (used for presence checks).
 // out has allocated entries for all shards (used for writing output).
-func (r *leopardFF16) reconstructChunk(sh, out [][]byte, work [][]byte, m, n int, errLocs *[order]ffe, useBits bool, errorBits *errorBitfield, recoverAll bool) {
+func (r *leopardFF16) reconstructChunk(sh, out [][]byte, work [][]byte, m, n, inputCount int, errLocs *[order]ffe, useBits bool, errorBits *errorBitfield, recoverAll bool) {
 	const LEO_ERROR_BITFIELD_OPT = true
 	outputCount := m + r.dataShards
 
@@ -606,7 +609,7 @@ func (r *leopardFF16) reconstructChunk(sh, out [][]byte, work [][]byte, m, n int
 
 	// work <- IFFT(work, n, 0)
 	ifftDITDecoder(
-		m+r.dataShards,
+		inputCount,
 		work,
 		n,
 		fftSkew[:],

--- a/reedsolomon_test.go
+++ b/reedsolomon_test.go
@@ -1523,6 +1523,12 @@ func BenchmarkReconstructLeopard50x20x1M(b *testing.B) {
 	benchmarkReconstruct(b, 50, 20, 1024*1024, WithLeopardGF(true), WithInversionCache(true))
 }
 
+func BenchmarkReconstructDataLeopardGF16(b *testing.B) {
+	b.Run("sparse-data-only", func(b *testing.B) {
+		benchmarkReconstructDataSparse(b, 1024, 3072, 4096, WithLeopardGF16(true))
+	})
+}
+
 // Benchmark 10 data slices with 4 parity slices holding 16MB bytes each
 func BenchmarkReconstruct10x4x16M(b *testing.B) {
 	benchmarkReconstruct(b, 10, 4, 16*1024*1024)
@@ -1559,6 +1565,44 @@ func benchmarkReconstructData(b *testing.B, dataShards, parityShards, shardSize 
 
 		err = r.ReconstructData(shards)
 		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func benchmarkReconstructDataSparse(b *testing.B, dataShards, parityShards, shardSize int, opts ...Option) {
+	o := []Option{WithAutoGoroutines(shardSize)}
+	o = append(o, opts...)
+	r, err := New(dataShards, parityShards, testOptions(o...)...)
+	if err != nil {
+		b.Fatal(err)
+	}
+	shards := r.(Extensions).AllocAligned(shardSize)
+
+	for s := range dataShards {
+		fillRandom(shards[s])
+	}
+	if err := r.Encode(shards); err != nil {
+		b.Fatal(err)
+	}
+
+	presentData := dataShards / 4
+	presentParity := dataShards - presentData
+	if presentParity > parityShards {
+		b.Fatalf("need %d parity shards, have %d", presentParity, parityShards)
+	}
+	for s := dataShards + presentParity; s < dataShards+parityShards; s++ {
+		shards[s] = nil
+	}
+
+	b.SetBytes(int64(shardSize * (dataShards + parityShards)))
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for s := presentData; s < dataShards; s++ {
+			shards[s] = shards[s][:0]
+		}
+		if err := r.ReconstructData(shards); err != nil {
 			b.Fatal(err)
 		}
 	}


### PR DESCRIPTION
This builds on the sparse ReconstructData path. Leopard GF16 reconstruction fills the decoder work vector from present parity shards and present original shards, but the decoder IFFT still used m+dataShards as the truncation bound.

Track the highest present original input while scanning shards and pass that bound into ifftDITDecoder. Missing original shards above that bound are already zero in the work vector, so they do not need to participate in the truncated decoder IFFT.

Incremental benchmark on top of leopard: use sparse FFT for data-only recovery, AMD Ryzen AI 9 HX 370, GOMAXPROCS=1:

before: 15.777-27.322 ms/op, 614-1063 MB/s, 49.4 KB/op, 10 allocs/op

after:  15.759-17.673 ms/op, 949-1065 MB/s, 49.4 KB/op, 10 allocs/op

Command: GOMAXPROCS=1 GOCACHE=/tmp/go-build-reedsolomon go test . -run=^$ -bench='^BenchmarkReconstructDataLeopardGF16$/^sparse-data-only$' -benchmem -benchtime=5x -count=10 -timeout=10m

Based on #340 (currently on master in fact, because it seems to be impossible to create stack PRs across forks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved data reconstruction efficiency when working with sparse or incomplete shard sets.
  * Reconstruction operations now intelligently limit processing to necessary data portions, reducing computational overhead.

* **Tests**
  * Added performance benchmarks for large-scale sparse data reconstruction scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klauspost/reedsolomon/pull/341?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->